### PR TITLE
Fallback to menu selection if multiple shortname matches

### DIFF
--- a/app/Commands/UninstallCommand.php
+++ b/app/Commands/UninstallCommand.php
@@ -55,21 +55,18 @@ class UninstallCommand extends Command
                 return substr($containerName, 0, strlen($service)) === $service;
             });
 
-        if ($serviceMatches->count() === 0) {
-            $this->error("\nCannot find a Takeout-managed instance of {$service}.");
-            return;
-        }
+        switch ($serviceMatches->count()) {
+            case 0:
+                return $this->error("\nCannot find a Takeout-managed instance of {$service}.");
+            case 1:
+                $serviceContainerId = $serviceMatches->flip()->first();
+                break;
+            default: // > 1
+                $serviceContainerId = $this->menu('Select which service to uninstall.', $serviceMatches->toArray())->open();
 
-        if ($serviceMatches->count() > 1) {
-            $serviceContainerId = $this->menu('Select which service to uninstall.', $serviceMatches->toArray())->open();
-
-            if (! $serviceContainerId) {
-                return;
-            }
-        }
-
-        if ($serviceMatches->count() === 1) {
-            $serviceContainerId = $serviceMatches->flip()->first();
+                if (! $serviceContainerId) {
+                    return;
+                }
         }
 
         $this->uninstallByContainerId($serviceContainerId);


### PR DESCRIPTION
During uninstall, if there are multiple service matches for a shortname, we open a menu to allow the user to select a specific service to uninstall. The selection will be filtered by the uninstallable services that match the shortname.

![Jul-24-2020 12-34-15](https://user-images.githubusercontent.com/2329654/88428621-147b9800-cdaa-11ea-8cb8-0dbbbf0271c7.gif)

Closes #27