### PR TITLE
Add MSSQL - Required Refactor of DockerTags

### DIFF
--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -15,6 +15,7 @@ abstract class BaseService
 
     protected $organization = 'library'; // Official repositories use `library` as the organization name.
     protected $imageName;
+    protected $dockerTagsClass = DockerTags::class;
     protected $tag;
     protected $installTemplate;
     protected $defaultPort;
@@ -35,14 +36,12 @@ abstract class BaseService
     protected $shell;
     protected $environment;
     protected $docker;
-    protected $dockerTags;
 
-    public function __construct(Shell $shell, Environment $environment, Docker $docker, DockerTags $dockerTags)
+    public function __construct(Shell $shell, Environment $environment, Docker $docker)
     {
         $this->shell = $shell;
         $this->environment = $environment;
         $this->docker = $docker;
-        $this->dockerTags = $dockerTags;
 
         $this->defaultPrompts = array_map(function ($prompt) {
             if ($prompt['shortname'] === 'port') {
@@ -132,7 +131,7 @@ abstract class BaseService
     protected function resolveTag($responseTag)
     {
         if ($responseTag === 'latest') {
-            return $this->dockerTags->getLatestTag($this->organization, $this->imageName);
+            return app()->make($this->dockerTagsClass, ['service' => $this])->getLatestTag();
         }
 
         return $responseTag;

--- a/app/Services/MsSql.php
+++ b/app/Services/MsSql.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services;
+
+use App\Shell\MicrosoftDockerTags;
+
+class MsSql extends BaseService
+{
+    protected $organization = 'mcr.microsoft.com';
+    protected $imageName = 'mssql/server';
+    protected $dockerTagsClass = MicrosoftDockerTags::class;
+    protected $defaultPort = 1433;
+    protected $prompts = [
+        [
+            'shortname' => 'sa_password',
+            'prompt' => 'What will the SA password be?',
+            'default' => 'useA$strongPas1337',
+        ],
+    ];
+
+    protected $installTemplate = '-p "$port":1433 \
+        -e ACCEPT_EULA=Y \
+        -e SA_PASSWORD="$sa_password" \
+        "$organization"/"$image_name":"$tag"';
+}

--- a/app/Shell/DockerTags.php
+++ b/app/Shell/DockerTags.php
@@ -2,6 +2,7 @@
 
 namespace App\Shell;
 
+use App\Services\BaseService;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Stream;
 use Psr\Http\Message\StreamInterface;
@@ -9,23 +10,25 @@ use Psr\Http\Message\StreamInterface;
 class DockerTags
 {
     protected $guzzle;
+    protected $service;
 
-    public function __construct(Client $guzzle)
+    public function __construct(Client $guzzle, BaseService $service)
     {
         $this->guzzle = $guzzle;
+        $this->service = $service;
     }
 
-    public function getLatestTag(string $organization, string $imageName): string
+    public function getLatestTag(): string
     {
-        return collect($this->getTags($organization, $imageName))->first(function ($tag) {
+        return collect($this->getTags())->first(function ($tag) {
             return $tag !== 'latest';
         });
     }
 
-    public function getTags(string $organization, string $imageName): array
+    public function getTags(): array
     {
         return $this->filterResponseForTags(
-            $this->getTagsResponse($organization, $imageName)
+            $this->getTagsResponse()
         );
     }
 
@@ -38,19 +41,24 @@ class DockerTags
             ->toArray();
     }
 
-    protected function getTagsResponse($organization, $imageName): StreamInterface
+    protected function getTagsResponse(): StreamInterface
     {
         return $this->guzzle
-            ->get($this->buildTagsUrl($organization, $imageName))
+            ->get($this->buildTagsUrl())
             ->getBody();
     }
 
-    protected function buildTagsUrl($organization, $imageName): string
+    protected function buildTagsUrl(): string
     {
         return sprintf(
-            'https://registry.hub.docker.com/v2/repositories/%s/%s/tags',
-            $organization,
-            $imageName
+            $this->tagsUrlTemplate(),
+            $this->service->organization(),
+            $this->service->imageName()
         );
+    }
+
+    protected function tagsUrlTemplate(): string
+    {
+        return 'https://registry.hub.docker.com/v2/repositories/%s/%s/tags';
     }
 }

--- a/app/Shell/MicrosoftDockerTags.php
+++ b/app/Shell/MicrosoftDockerTags.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Shell;
+
+use App\Services\BaseService;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Stream;
+use Illuminate\Support\Str;
+use Psr\Http\Message\StreamInterface;
+
+class MicrosoftDockerTags extends DockerTags
+{
+    protected $guzzle;
+    protected $service;
+
+    public function __construct(Client $guzzle, BaseService $service)
+    {
+        $this->guzzle = $guzzle;
+        $this->service = $service;
+    }
+
+    public function getLatestTag(): string
+    {
+        return collect(json_decode($this->getTagsResponse(), true)['tags'])
+            ->reverse()
+            ->filter(function ($tag) {
+                return Str::contains($tag, '-GA-');
+            })
+            ->first();
+    }
+
+    protected function tagsUrlTemplate(): string
+    {
+        return 'https://%s/v2/%s/tags/list';
+    }
+}

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -12,8 +12,8 @@ class DockerTagsTest extends TestCase
     function it_lists_10_newest_available_tags_for_service()
     {
         $mysql = app(MySql::class);
-        $dockerTags = app(DockerTags::class);
-        $tags = $dockerTags->getTags($mysql->organization(), $mysql->imageName());
+        $dockerTags = app(DockerTags::class, ['service' => $mysql]);
+        $tags = $dockerTags->getTags();
 
         $this->assertEquals('latest', $tags[0]);
         $this->assertTrue(in_array('5.7', $tags));


### PR DESCRIPTION
I was able to get volumes working with MSSQL by using this hack:
https://github.com/t-oster/mssql-docker-zfs

But it doesn't seem like it would fit into the takeout architecture as it is currently. Maybe we could eventually include custom dockerfiles that we could build custom images from. But this seems like too much for now.

I removed the volume prompt from MSSQL and I had to enter a strong default password. I don't know if we need to add this to docs or something, but the default user is not root, but `sa`.

Co-authored-by: Matt Stauffer <matt@tighten.co>

