### PR TITLE
Specify an optional nickname when enabling a service

### DIFF
--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -31,6 +31,11 @@ abstract class BaseService
             'prompt' => 'Which tag (version) of this service would you like to use?',
             'default' => 'latest',
         ],
+        [
+            'shortname' => 'nickname',
+            'prompt' => 'Enter a nickname for this container',
+            // Default is set in the constructor
+        ],
     ];
     protected $prompts;
     protected $promptResponses = [];
@@ -48,6 +53,9 @@ abstract class BaseService
         $this->defaultPrompts = array_map(function ($prompt) {
             if ($prompt['shortname'] === 'port') {
                 $prompt['default'] = $this->defaultPort;
+            }
+            if ($prompt['shortname'] === 'nickname') {
+                $prompt['default'] = uniqid();
             }
             return $prompt;
         }, $this->defaultPrompts);
@@ -95,6 +103,11 @@ abstract class BaseService
     public function shortName(): string
     {
         return strtolower(class_basename(static::class));
+    }
+
+    public function nickname(): string
+    {
+        return Str::slug($this->promptResponses['nickname']);
     }
 
     public function defaultPort(): int
@@ -155,6 +168,6 @@ abstract class BaseService
 
     protected function containerName(): string
     {
-        return 'TO--' . $this->shortName() . '--' . $this->tag;
+        return 'TO--' . $this->shortName() . '--' . $this->nickname() . '--' . $this->tag;
     }
 }

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -107,7 +107,7 @@ abstract class BaseService
 
     public function nickname(): string
     {
-        return Str::slug($this->promptResponses['nickname']);
+        return Str::slug($this->promptResponses['nickname'] ?? '');
     }
 
     public function defaultPort(): int
@@ -168,6 +168,13 @@ abstract class BaseService
 
     protected function containerName(): string
     {
-        return 'TO--' . $this->shortName() . '--' . $this->nickname() . '--' . $this->tag;
+        return collect([
+            'TO',
+            $this->shortName(),
+            $this->tag,
+            $this->nickname(),
+        ])->filter(function($str) {
+            return !empty($str);
+        })->join('--');
     }
 }


### PR DESCRIPTION
This PR is based on the discussion happening in #77 

## The Problem

When creating multiple service containers of the same version you will run into naming conflicts. 

ex:

```
 ERR  docker: Error response from daemon: Conflict. The container name "/TO--mariadb--focal" is already in use by container "1605cd2ae8729609ec3e62e43268e92ec2891c27f9d7ae9fcf2bb8c302c39718". You have to remove (or rename) that container to be able to reuse that name.
See 'docker run --help'.
```

## The Solution

Prompt the user for a nickname (defaults to a `uniqid()`) that we add to the container name to ensure uniqueness

## Considerations

* No tests yet
* I chose the word `nickname` based on the discussion in the issue
* We could do a retry prompt similar to the one for choosing a port if there is a name conflict
* I chose to use a unique string instead of the volume name as a fallback, but we could easily add that in

Happy to hear feedback 😄 