### PR TITLE
Use lsof to better handle port info

### DIFF
--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -118,7 +118,14 @@ abstract class BaseService
             $this->askQuestion($prompt);
 
             while ($prompt['shortname'] === 'port' && ! $this->environment->portIsAvailable($this->promptResponses['port'])) {
-                app('console')->error("Port {$this->promptResponses['port']} is already in use. Please select a different port.\n");
+                $port_info = $this->environment->portInfo($this->promptResponses['port']);
+                if ($port_info && count($port_info) === 3) {
+                    list($process_name, $pid, $user) = $port_info;
+                    app('console')->error("Port {$this->promptResponses['port']} is used by process PID {$pid} named {$process_name} by user {$user}. Please select a different port.\n");
+                } else {
+                    app('console')->error("Port {$this->promptResponses['port']} is already in use. Please select a different port.\n");
+                }
+
                 $this->askQuestion($prompt);
             }
         }

--- a/app/Shell/Environment.php
+++ b/app/Shell/Environment.php
@@ -19,4 +19,11 @@ class Environment
         // A successful netstat command means a port in use was found
         return ! $process->isSuccessful();
     }
+
+    public function portInfo($port): array
+    {
+        $process = $this->shell
+            ->execQuietly("lsof -n -P | grep -Ei 'ipv4.*:{$port}' |  tr -s ' ' | cut -d' ' -f1,2,3");
+        return $process->isSuccessful() ? explode(" ", trim($process->getOutput())) : [];
+    }
 }


### PR DESCRIPTION
Hi, this pull req solve in another way this problem: #87 (issue #58 )

## Problem
Currently, if the connected database client is left open and a container is disabled, then the port is "read' as being in use.

## Suggested Solution
Add a new method (`portInfo($port)`) to render process info with lsof.
`lsof -n -P | grep -Ei 'ipv4.*:{$port}' |  tr -s ' ' | cut -d' ' -f1,2,3`

## New expectation
Inform which pid, process and user still using that port.