### PR TITLE
Fix MySQL default auth for PHP < 7.4

### DIFF
--- a/app/Services/MySql.php
+++ b/app/Services/MySql.php
@@ -22,7 +22,7 @@ class MySql extends BaseService
     protected $dockerRunTemplate = '-p "${:port}":3306 \
         -e MYSQL_ROOT_PASSWORD="${:root_password}" \
         -v "${:volume}":/var/lib/mysql \
-        "${:organization}"/"${:image_name}":"${:tag}"';
+        "${:organization}"/"${:image_name}":"${:tag}" --default-authentication-plugin=mysql_native_password';
 
     protected static $displayName = 'MySQL';
 }


### PR DESCRIPTION
The alternative is to edit the user after the container is created but that’s less than ideal. This should “just work” out of the box when the user is using an older PHP version.

I opted to not do detection because it's possible that the PHP version connecting to MySQL is different than the one used to start the container (e.g. if you're using takeout on the host machine + an older homestead box)

fixes #53