### PR TITLE
Allow enabling/disabling multiple services at once

### DIFF
--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -11,7 +11,7 @@ class DisableCommand extends Command
 {
     use InitializesCommands;
 
-    protected $signature = 'disable {serviceNames*}';
+    protected $signature = 'disable {serviceNames?*}';
     protected $description = 'Disable services.';
     protected $disableableServices;
     protected $docker;

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -11,8 +11,8 @@ class DisableCommand extends Command
 {
     use InitializesCommands;
 
-    protected $signature = 'disable {serviceName?}';
-    protected $description = 'Disable a service.';
+    protected $signature = 'disable {serviceNames*}';
+    protected $description = 'Disable services.';
     protected $disableableServices;
     protected $docker;
 
@@ -27,8 +27,12 @@ class DisableCommand extends Command
             return;
         }
 
-        if ($this->argument('serviceName')) {
-            return $this->disableByServiceName($this->argument('serviceName'));
+        if (filled($services = $this->argument('serviceNames'))) {
+            foreach ($services as $service) {
+                $this->disableByServiceName($service);
+            }
+
+            return;
         }
 
         $this->showDisableServiceMenu();

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -11,7 +11,7 @@ class EnableCommand extends Command
 {
     use InitializesCommands;
 
-    protected $signature = 'enable {serviceNames*}';
+    protected $signature = 'enable {serviceNames?*}';
     protected $description = 'Enable services.';
 
     public function handle(): void

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -11,17 +11,20 @@ class EnableCommand extends Command
 {
     use InitializesCommands;
 
-    protected $signature = 'enable {serviceName?}';
-    protected $description = 'Enable a service.';
+    protected $signature = 'enable {serviceNames*}';
+    protected $description = 'Enable services.';
 
     public function handle(): void
     {
         $this->initializeCommand();
 
-        $service = $this->argument('serviceName');
+        $services = $this->argument('serviceNames');
 
-        if ($service) {
-            $this->enable($service);
+        if (filled($services)) {
+            foreach ($services as $service) {
+                $this->enable($service);
+            }
+
             return;
         }
 

--- a/tests/Feature/EnableCommandTest.php
+++ b/tests/Feature/EnableCommandTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Exceptions\InvalidServiceShortnameException;
 use App\Services\MeiliSearch;
+use App\Services\PostgreSql;
 use App\Shell\Docker;
 use Tests\TestCase;
 
@@ -25,6 +26,30 @@ class EnableCommandTest extends TestCase
         });
 
         $this->artisan('enable ' . $service);
+    }
+
+    /** @test */
+    function it_finds_multiple_services()
+    {
+        $meilisearch = 'meilisearch';
+        $postgres = 'postgres';
+
+        $this->mock(MeiliSearch::class, function ($mock) use ($meilisearch) {
+            $mock->shouldReceive('enable')->once();
+            $mock->shouldReceive('shortName')->andReturn($meilisearch);
+        });
+
+        $this->mock(PostgreSql::class, function ($mock) use ($postgres) {
+            $mock->shouldReceive('enable')->once();
+            $mock->shouldReceive('shortName')->andReturn($postgres);
+        });
+
+        $this->mock(Docker::class, function ($mock) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+        });
+
+        $this->artisan("enable {$meilisearch} {$postgres}");
     }
 
     /** @test */


### PR DESCRIPTION
Something @loganhenson said got me thinking about making it even smoother to spin multiple services up at once, so just PRing this as an idea. Before:

```bash
takeout enable meilisearch
# ...
takeout enable beanstalkd
```

After:

```bash
takeout enable meilisearch beanstalkd
```

I installed docker and manually tested this a bit and it works great, but I only really explored the happy path. I'm pretty sure this would still play nicely with other options or flags being passed to `enable` if that were added at some point.