### PR TITLE
Detect OS after all containers are disabled to prevent docker service…

### DIFF
--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -91,7 +91,7 @@ class DisableCommand extends Command
                 $this->info("\n docker volume rm {$volumeName}");
             }
 
-            if (count($this->docker->allContainers()) === 0) {
+            if (count($this->docker->allContainers()) === 0 && in_array(PHP_OS_FAMILY, ['Darwin','Windows'])) {
                 $option = $this->menu('No containers are running. Turn off Docker for Mac?', [
                     'Yes',
                     'No',


### PR DESCRIPTION
HI, this solve #131 .

php from 7.2 offer a new constant `PHP_OS_FAMILY` to determine OS family. (https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family)