### PR TITLE
Using --default option

### DIFF
--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -58,7 +58,6 @@ class DisableCommand extends Command
 
     public function disableByServiceName(string $service): void
     {
-        dd($service);
         $serviceMatches = collect($this->disableableServices)
             ->filter(function ($containerName) use ($service) {
                 return substr($containerName, 0, strlen($service)) === $service;

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -2,10 +2,10 @@
 
 namespace App\Commands;
 
-use Throwable;
-use App\Shell\Docker;
 use App\InitializesCommands;
+use App\Shell\Docker;
 use LaravelZero\Framework\Commands\Command;
+use Throwable;
 
 class DisableCommand extends Command
 {
@@ -22,9 +22,7 @@ class DisableCommand extends Command
         $this->initializeCommand();
         $this->disableableServices = $this->disableableServices();
 
-        $disableAll = $this->option('all');
-
-        if ($disableAll) {
+        if ($this->option('all')) {
             foreach ($this->disableableServices as $containerId => $name) {
                 $this->disableByContainerId($containerId);
             }

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -2,16 +2,15 @@
 
 namespace App\Commands;
 
-use App\InitializesCommands;
 use App\Services;
-use Illuminate\Support\Str;
+use App\InitializesCommands;
 use LaravelZero\Framework\Commands\Command;
 
 class EnableCommand extends Command
 {
     use InitializesCommands;
 
-    protected $signature = 'enable {serviceName?}';
+    protected $signature = 'enable {serviceName?} {--default}';
     protected $description = 'Enable a service.';
 
     public function handle(): void
@@ -20,8 +19,11 @@ class EnableCommand extends Command
 
         $service = $this->argument('serviceName');
 
+        $useDefaults = $this->option('default');
+
         if ($service) {
-            $this->enable($service);
+            $this->enable($service, $useDefaults);
+
             return;
         }
 
@@ -44,9 +46,9 @@ class EnableCommand extends Command
         })->toArray();
     }
 
-    public function enable(string $service): void
+    public function enable(string $service, bool $useDefaults = false): void
     {
         $fqcn = (new Services)->get($service);
-        app($fqcn)->enable();
+        app($fqcn)->enable($useDefaults);
     }
 }

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -2,8 +2,8 @@
 
 namespace App\Commands;
 
-use App\Services;
 use App\InitializesCommands;
+use App\Services;
 use LaravelZero\Framework\Commands\Command;
 
 class EnableCommand extends Command

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -2,13 +2,13 @@
 
 namespace App\Services;
 
-use Throwable;
-use App\Shell\Shell;
 use App\Shell\Docker;
-use App\WritesToConsole;
 use App\Shell\DockerTags;
 use App\Shell\Environment;
+use App\Shell\Shell;
+use App\WritesToConsole;
 use Illuminate\Support\Str;
+use Throwable;
 
 abstract class BaseService
 {
@@ -180,6 +180,6 @@ abstract class BaseService
             }
         }
 
-        return 'TO--' . $this->shortName() . '--' . $this->tag . '--' . $portTag;
+        return 'TO--' . $this->shortName() . '--' . $this->tag . $portTag;
     }
 }

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -2,13 +2,13 @@
 
 namespace App\Services;
 
+use Throwable;
+use App\Shell\Shell;
 use App\Shell\Docker;
+use App\WritesToConsole;
 use App\Shell\DockerTags;
 use App\Shell\Environment;
-use App\Shell\Shell;
-use App\WritesToConsole;
 use Illuminate\Support\Str;
-use Throwable;
 
 abstract class BaseService
 {
@@ -38,6 +38,7 @@ abstract class BaseService
     protected $environment;
     protected $docker;
     protected static $displayName;
+    protected $useDefaults = false;
 
     public function __construct(Shell $shell, Environment $environment, Docker $docker)
     {
@@ -49,6 +50,7 @@ abstract class BaseService
             if ($prompt['shortname'] === 'port') {
                 $prompt['default'] = $this->defaultPort;
             }
+
             return $prompt;
         }, $this->defaultPrompts);
 
@@ -63,9 +65,12 @@ abstract class BaseService
         return static::$displayName ?? Str::afterLast(static::class, '\\');
     }
 
-    public function enable(): void
+    public function enable(bool $useDefaults = false): void
     {
+        $this->useDefaults = $useDefaults;
+
         $this->prompts();
+
         $this->ensureImageIsDownloaded();
 
         $this->info("Enabling {$this->shortName()}...\n");
@@ -114,8 +119,10 @@ abstract class BaseService
 
     protected function prompts(): void
     {
+        $items = [];
+
         foreach ($this->defaultPrompts as $prompt) {
-            $this->askQuestion($prompt);
+            $this->askQuestion($prompt, $this->useDefaults);
 
             while ($prompt['shortname'] === 'port' && ! $this->environment->portIsAvailable($this->promptResponses['port'])) {
                 app('console')->error("Port {$this->promptResponses['port']} is already in use. Please select a different port.");
@@ -124,15 +131,26 @@ abstract class BaseService
         }
 
         foreach ($this->prompts as $prompt) {
-            $this->askQuestion($prompt);
+            $this->askQuestion($prompt, $this->useDefaults);
+
+            while (Str::contains($prompt['shortname'], 'port') && ! $this->environment->portIsAvailable($this->promptResponses[$prompt['shortname']])) {
+                app('console')->error("Port {$this->promptResponses[$prompt['shortname']]} is already in use. Please select a different port.");
+                $this->askQuestion($prompt);
+            }
+
+            $items[] = $prompt;
         }
 
         $this->tag = $this->resolveTag($this->promptResponses['tag']);
     }
 
-    protected function askQuestion(array $prompt): void
+    protected function askQuestion(array $prompt, $useDefaults = false): void
     {
-        $this->promptResponses[$prompt['shortname']] = app('console')->ask($prompt['prompt'], $prompt['default'] ?? null);
+        $this->promptResponses[$prompt['shortname']] = $prompt['default'] ?? null;
+
+        if (! $useDefaults) {
+            $this->promptResponses[$prompt['shortname']] = app('console')->ask($prompt['prompt'], $prompt['default'] ?? null);
+        }
     }
 
     protected function resolveTag($responseTag): string
@@ -155,6 +173,13 @@ abstract class BaseService
 
     protected function containerName(): string
     {
-        return 'TO--' . $this->shortName() . '--' . $this->tag;
+        $portTag = '';
+        foreach ($this->promptResponses as $key => $value) {
+            if (Str::contains($key, 'port')) {
+                $portTag .= "--{$value}";
+            }
+        }
+
+        return 'TO--' . $this->shortName() . '--' . $this->tag . '--' . $portTag;
     }
 }

--- a/app/Shell/Environment.php
+++ b/app/Shell/Environment.php
@@ -2,6 +2,8 @@
 
 namespace App\Shell;
 
+use Illuminate\Support\Str;
+
 class Environment
 {
     protected $shell;
@@ -11,10 +13,34 @@ class Environment
         $this->shell = $shell;
     }
 
+    private function isLinuxOs()
+    {
+        return PHP_OS_FAMILY === 'Linux';
+    }
+
     public function portIsAvailable($port): bool
     {
+        $isLinux = $this->isLinuxOs();
+        $netstatCmd = 'netstat';
+        $portText = "\.{$port}\s"; // mac default port behavior 127.0.0.1.3306 for mysql
+
+        // if its linux we need to check WSL also,
+        // because WSL runs docker from Windows host
+        // and it uses netstat.exe from Windows
+        // if we don't use this, WSL won't find ports conflict
+        if ($isLinux) {
+            $portText = "\:{$port}\s"; // win/linux default port behavior 127.0.0.1:3306 for mysql
+
+            $linuxVersion = $this->shell->execQuietly('cat /proc/version');
+            $isWSL = Str::contains($linuxVersion->getOutput(), 'microsoft');
+
+            if ($isWSL) {
+                $netstatCmd = 'netstat.exe';
+            }
+        }
+
         // Check to see if the system is running a service with the desired port
-        $process = $this->shell->execQuietly("netstat -vanp tcp | grep '\.{$port}\s' | grep -v 'TIME_WAIT' | grep -v 'CLOSE_WAIT' | grep -v 'FIN_WAIT'");
+        $process = $this->shell->execQuietly("{$netstatCmd} -vanp tcp | grep '{$portText}' | grep -v 'TIME_WAIT' | grep -v 'CLOSE_WAIT' | grep -v 'FIN_WAIT'");
 
         // A successful netstat command means a port in use was found
         return ! $process->isSuccessful();

--- a/tests/Feature/BaseServiceTest.php
+++ b/tests/Feature/BaseServiceTest.php
@@ -2,26 +2,26 @@
 
 namespace Tests\Feature;
 
-use App\Services\MeiliSearch;
-use App\Shell\Docker;
-use App\Shell\Shell;
-use LaravelZero\Framework\Commands\Command;
-use Mockery as M;
-use Symfony\Component\Process\Process;
-use Tests\TestCase;
 use function app;
+use Mockery as M;
+use Tests\TestCase;
+use App\Shell\Shell;
+use App\Shell\Docker;
+use App\Services\MeiliSearch;
+use Symfony\Component\Process\Process;
+use LaravelZero\Framework\Commands\Command;
 
 class BaseServiceTest extends TestCase
 {
     /** @test */
-    function it_generates_shortname()
+    public function it_generates_shortname()
     {
         $meilisearch = app(MeiliSearch::class);
         $this->assertEquals('meilisearch', $meilisearch->shortName());
     }
 
     /** @test */
-    function it_enables_services()
+    public function it_enables_services()
     {
         app()->instance('console', M::mock(Command::class, function ($mock) {
             $defaultPort = app(MeiliSearch::class)->defaultPort();
@@ -33,6 +33,7 @@ class BaseServiceTest extends TestCase
         $this->mock(Shell::class, function ($mock) {
             $process = M::mock(Process::class);
             $process->shouldReceive('isSuccessful')->andReturn(false);
+            $process->shouldReceive('getOutput')->andReturn('');
 
             $mock->shouldReceive('execQuietly')->andReturn($process);
         });
@@ -45,7 +46,7 @@ class BaseServiceTest extends TestCase
             $mock->shouldReceive('bootContainer')->with(['getmeili/meilisearch']);
         });
 
-        $service = app(MeiliSearch::Class); // Extends BaseService
+        $service = app(MeiliSearch::class); // Extends BaseService
         $service->enable();
     }
 }

--- a/tests/Feature/DisableCommandTest.php
+++ b/tests/Feature/DisableCommandTest.php
@@ -2,11 +2,23 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
 use App\Commands\DisableCommand;
+use App\Shell\Docker;
+use Tests\TestCase;
 
 class DisableCommandTest extends TestCase
 {
+    protected function setup(): void
+    {
+        parent::setUp();
+
+        $this->mock(Docker::class, function ($mock) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+            $mock->shouldIgnoreMissing();
+        });
+    }
+
     /** @test */
     public function disable_menu_is_shown_when_no_service_in_input()
     {
@@ -15,6 +27,7 @@ class DisableCommandTest extends TestCase
                 'fake-id' => 'TO-mysql--latest--3306',
             ]);
             $mock->shouldReceive('showDisableServiceMenu');
+            $mock->shouldIgnoreMissing();
         });
 
         $this->artisan('disable');
@@ -30,6 +43,7 @@ class DisableCommandTest extends TestCase
             $mock->shouldReceive('disableableServices')->andReturn([
                 'fake-id' => "TO-{$service}--latest--3306",
             ]);
+            $mock->shouldIgnoreMissing();
         });
 
         $this->artisan('disable ' . $service);
@@ -47,13 +61,14 @@ class DisableCommandTest extends TestCase
                 'fake-id' => "TO-{$mysql}--latest--3306",
                 'fake-id' => "TO-{$postgres}--latest--5432",
             ]);
+            $mock->shouldIgnoreMissing();
         });
 
         $this->artisan("disable {$mysql} {$postgres}");
     }
 
     /** @test */
-    public function all_services_will_be_disabled_if_all_flag_passwd()
+    public function all_services_will_be_disabled_if_all_flag_passed()
     {
         $mysql = 'mysql';
         $postgres = 'postgres';

--- a/tests/Feature/DisableCommandTest.php
+++ b/tests/Feature/DisableCommandTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use App\Shell\Docker;
 use App\Commands\DisableCommand;
+use App\Shell\Docker;
+use Tests\TestCase;
 
 class DisableCommandTest extends TestCase
 {

--- a/tests/Feature/DisableCommandTest.php
+++ b/tests/Feature/DisableCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Commands\DisableCommand;
+
+class DisableCommandTest extends TestCase
+{
+    /** @test */
+    public function disable_menu_is_shown_when_no_service_in_input()
+    {
+        $this->mock(DisableCommand::class, function ($mock) {
+            $mock->shouldReceive('disableableServices')->andReturn([
+                'fake-id' => 'TO-mysql--latest--3306',
+            ]);
+            $mock->shouldReceive('showDisableServiceMenu');
+        });
+
+        $this->artisan('disable');
+    }
+
+    /** @test */
+    public function single_service_can_be_disabled()
+    {
+        $service = 'mysql';
+
+        $this->mock(DisableCommand::class, function ($mock) use ($service) {
+            $mock->shouldReceive('disableByServiceName');
+            $mock->shouldReceive('disableableServices')->andReturn([
+                'fake-id' => "TO-{$service}--latest--3306",
+            ]);
+        });
+
+        $this->artisan('disable ' . $service);
+    }
+
+    /** @test */
+    public function multiple_services_can_be_disabled()
+    {
+        $mysql = 'mysql';
+        $postgres = 'postgres';
+
+        $this->mock(DisableCommand::class, function ($mock) use ($mysql, $postgres) {
+            $mock->shouldReceive('disableByServiceName')->andReturn(null);
+            $mock->shouldReceive('disableableServices')->andReturn([
+                'fake-id' => "TO-{$mysql}--latest--3306",
+                'fake-id' => "TO-{$postgres}--latest--5432",
+            ]);
+        });
+
+        $this->artisan("disable {$mysql} {$postgres}");
+    }
+
+    /** @test */
+    public function all_services_will_be_disabled_if_all_flag_passwd()
+    {
+        $mysql = 'mysql';
+        $postgres = 'postgres';
+
+        $this->mock(DisableCommand::class, function ($mock) use ($mysql, $postgres) {
+            $mock->shouldReceive('disableByContainerId');
+            $mock->shouldReceive('disableableServices')->andReturn([
+                'fake-id' => "TO-{$mysql}--latest--3306",
+                'fake-id' => "TO-{$postgres}--latest--5432",
+            ]);
+
+            $mock->shouldIgnoreMissing();
+        });
+
+        $this->artisan('disable', [
+            '--all' => true,
+        ]);
+    }
+}

--- a/tests/Feature/EnableCommandTest.php
+++ b/tests/Feature/EnableCommandTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 class EnableCommandTest extends TestCase
 {
     /** @test */
-    function it_finds_services_by_shortname()
+    public function it_finds_services_by_shortname()
     {
         $service = 'meilisearch';
 
@@ -29,7 +29,7 @@ class EnableCommandTest extends TestCase
     }
 
     /** @test */
-    function it_finds_multiple_services()
+    public function it_finds_multiple_services()
     {
         $meilisearch = 'meilisearch';
         $postgres = 'postgres';
@@ -53,7 +53,7 @@ class EnableCommandTest extends TestCase
     }
 
     /** @test */
-    function it_displays_error_if_invalid_shortname_passed()
+    public function it_displays_error_if_invalid_shortname_passed()
     {
         $this->mock(Docker::class, function ($mock) {
             $mock->shouldReceive('isInstalled')->andReturn(true);

--- a/tests/Feature/EnvironmentTest.php
+++ b/tests/Feature/EnvironmentTest.php
@@ -2,17 +2,17 @@
 
 namespace Tests\Feature;
 
-use App\Shell\Environment;
-use App\Shell\Shell;
-use LaravelZero\Framework\Commands\Command;
 use Mockery as M;
-use Symfony\Component\Process\Process;
 use Tests\TestCase;
+use App\Shell\Shell;
+use App\Shell\Environment;
+use Symfony\Component\Process\Process;
+use LaravelZero\Framework\Commands\Command;
 
 class EnvironmentTest extends TestCase
 {
     /** @test **/
-    function it_detects_a_port_conflict()
+    public function it_detects_a_port_conflict()
     {
         app()->instance('console', M::mock(Command::class, function ($mock) {
             $mock->shouldIgnoreMissing();
@@ -21,16 +21,17 @@ class EnvironmentTest extends TestCase
         $this->mock(Shell::class, function ($mock) {
             $process = M::mock(Process::class);
             $process->shouldReceive('isSuccessful')->once()->andReturn(true);
+            $process->shouldReceive('getOutput')->andReturn('');
 
-            $mock->shouldReceive('execQuietly')->once()->andReturn($process);
+            $mock->shouldReceive('execQuietly')->twice()->andReturn($process);
         });
 
-        $environment = app(Environment::Class);
+        $environment = app(Environment::class);
         $this->assertFalse($environment->portIsAvailable(1234));
     }
 
     /** @test **/
-    function it_detects_a_port_is_available()
+    public function it_detects_a_port_is_available()
     {
         app()->instance('console', M::mock(Command::class, function ($mock) {
             $mock->shouldIgnoreMissing();
@@ -39,11 +40,12 @@ class EnvironmentTest extends TestCase
         $this->mock(Shell::class, function ($mock) {
             $process = M::mock(Process::class);
             $process->shouldReceive('isSuccessful')->once()->andReturn(false);
+            $process->shouldReceive('getOutput')->andReturn('microsoft');
 
-            $mock->shouldReceive('execQuietly')->once()->andReturn($process);
+            $mock->shouldReceive('execQuietly')->twice()->andReturn($process);
         });
 
-        $environment = app(Environment::Class);
+        $environment = app(Environment::class);
         $this->assertTrue($environment->portIsAvailable(1234));
     }
 }

--- a/tests/Feature/EnvironmentTest.php
+++ b/tests/Feature/EnvironmentTest.php
@@ -11,6 +11,11 @@ use LaravelZero\Framework\Commands\Command;
 
 class EnvironmentTest extends TestCase
 {
+    private function isLinux()
+    {
+        return PHP_OS_FAMILY === 'Linux';
+    }
+
     /** @test **/
     public function it_detects_a_port_conflict()
     {
@@ -23,7 +28,12 @@ class EnvironmentTest extends TestCase
             $process->shouldReceive('isSuccessful')->once()->andReturn(true);
             $process->shouldReceive('getOutput')->andReturn('');
 
-            $mock->shouldReceive('execQuietly')->twice()->andReturn($process);
+            $times = 1;
+            if ($this->isLinux()) {
+                $times = 2;
+            }
+
+            $mock->shouldReceive('execQuietly')->times($times)->andReturn($process);
         });
 
         $environment = app(Environment::class);
@@ -40,9 +50,14 @@ class EnvironmentTest extends TestCase
         $this->mock(Shell::class, function ($mock) {
             $process = M::mock(Process::class);
             $process->shouldReceive('isSuccessful')->once()->andReturn(false);
-            $process->shouldReceive('getOutput')->andReturn('microsoft');
+            $process->shouldReceive('getOutput')->andReturn('');
 
-            $mock->shouldReceive('execQuietly')->twice()->andReturn($process);
+            $times = 1;
+            if ($this->isLinux()) {
+                $times = 2;
+            }
+
+            $mock->shouldReceive('execQuietly')->times($times)->andReturn($process);
         });
 
         $environment = app(Environment::class);

--- a/tests/Feature/ServiceEnableDefaultTest.php
+++ b/tests/Feature/ServiceEnableDefaultTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use Mockery as M;
+use Tests\TestCase;
+use App\Shell\Docker;
+use App\Services\MailHog;
+
+class ServiceEnableDefaultTest extends TestCase
+{
+    /** @test */
+    public function it_enables_service_when_default_flag_is_provided()
+    {
+        app()->instance('console', M::mock(Command::class, function ($mock) {
+            $defaultPort = app(MailHog::class)->defaultPort();
+            $mock->shouldReceive('ask')->with('Which host port would you like this service to use?', $defaultPort)->andReturn(7700);
+            $mock->shouldReceive('ask')->with('Which host port would you like this service to use?', $defaultPort)->andReturn(77001);
+            $mock->shouldReceive('ask')->with('Which tag (version) of this service would you like to use?', 'latest')->andReturn('latest');
+            $mock->shouldIgnoreMissing();
+        }));
+
+        $this->mock(Shell::class, function ($mock) {
+            $process = M::mock(Process::class);
+            $process->shouldReceive('isSuccessful')->andReturn(true);
+            $process->shouldReceive('isSuccessful')->andReturn(false);
+            $process->shouldReceive('getOutput')->andReturn('');
+
+            $mock->shouldReceive('execQuietly')->andReturn($process);
+        });
+
+        $service = 'mailhog';
+        $this->mock(MailHog::class, function ($mock) use ($service) {
+            $mock->shouldReceive('enable')->with(true)->twice();
+            $mock->shouldReceive('shortName')->andReturn($service);
+        });
+
+        $this->mock(Docker::class, function ($mock) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+            $mock->shouldReceive('imageIsDownloaded')->andReturn(true);
+
+            // This is the actual assertion
+            $mock->shouldReceive('bootContainer')->with(['mailhog/mailhog']);
+        });
+
+        $this->artisan('enable ' . $service . ' --default');
+
+        $service = app(MailHog::class); // Extends BaseService
+        $service->enable(true);
+    }
+}


### PR DESCRIPTION
I have worked out on using --default on any enable command to use default ports and tags or keys

can be useful if you create many services at once as per your project setup
#130 

I have edited the Environment.php to check ports availability on Linux and WSL
And I have edited the container name, so that it will not conflict when creating 2 docker container with same version but with different ports