### PR TITLE
[ISSUE-112] : Updated stopDockerService method to work on Linux, MacOS and Windows

### DIFF
--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -95,8 +95,8 @@ class DisableCommand extends Command
                 $this->info("\n docker volume rm {$volumeName}");
             }
 
-            if (count($this->docker->allContainers()) === 0 && in_array(PHP_OS_FAMILY, ['Darwin','Windows'])) {
-                $option = $this->menu('No containers are running. Turn off Docker for Mac?', [
+            if (count($this->docker->allContainers()) === 0 && in_array(PHP_OS_FAMILY, ['Darwin','Windows','Linux'])) {
+                $option = $this->menu('No containers are running. Turn off Docker?', [
                     'Yes',
                     'No',
                 ])->disableDefaultItems()->open();

--- a/app/Shell/Docker.php
+++ b/app/Shell/Docker.php
@@ -142,8 +142,10 @@ class Docker
         if (PHP_OS_FAMILY === 'Windows') {
             $this->shell->execQuietly("wsl -t docker-desktop");
             $this->shell->execQuietly("wsl -t docker-desktop-data");
+        } else if (PHP_OS_FAMILY === 'Darwin') {
+            $this->shell->execQuietly("test -z $(docker ps -q 2>/dev/null) && osascript -e 'quit app \"Docker\"'");
         } else {
-            $this->shell->execQuietly("killall Docker");
+            $this->shell->execQuietly("systemctl stop docker");
         }
     }
 }

--- a/app/Shell/Docker.php
+++ b/app/Shell/Docker.php
@@ -139,6 +139,11 @@ class Docker
 
     public function stopDockerService(): void
     {
-        $this->shell->execQuietly("test -z $(docker ps -q 2>/dev/null) && osascript -e 'quit app \"Docker\"'");
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->shell->execQuietly("wsl -t docker-desktop");
+            $this->shell->execQuietly("wsl -t docker-desktop-data");
+        } else {
+            $this->shell->execQuietly("killall Docker");
+        }
     }
 }


### PR DESCRIPTION
Issue link : [ISSUE-112](https://github.com/tighten/takeout/issues/112)

### Description
- Modified _stopDockerService_ method to perform the following checks :
   - if takeout project is running on Windows, then
      - stop docker distros running over WSL2
   - Otherwise, if takeout project is running on MacOS, then
      - stop Docker app 
   - Otherwise, takeout project is running in linux platform
     - stop docker using systemctl command

- Modified _disableByContainerId_ function, to call _stopDockerService_ method if user opts for it, when the project is running over Windows, Darwin or Linux platform

### Manual Testing Done
- When all of the services enabled using takeout tool is disabled, the user is then **provided** with an option to stop docker 
  service
- When all of the services enabled using takeout tool is disabled, but there are some docker containers started by user without using the takeout tool is running, then the user is **not provided** with an option to stop docker 
- When not all of the services enabled using takeout tool is disabled, then the user is **not provided** with an option to stop docker
- Since i am not able to build the project as reported [here](https://github.com/tighten/takeout/issues/112#issuecomment-702301024), I manually set up docker in linux( Centos, Fedora, Ubuntu) , windows and MacOS platforms to check if provided shell command solutions work as expected in corresponding platforms.