### PR TITLE
Add github actions status to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # Takeout
 
+[![Actions Status](https://img.shields.io/github/workflow/status/tighten/takeout/Run%20tests)](https://github.com/tighten/takeout/actions)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/tightenco/takeout.svg?style=flat)](https://packagist.org/packages/tightenco/takeout)
 [![Downloads on Packagist](https://img.shields.io/packagist/dt/tightenco/takeout.svg?style=flat)](https://packagist.org/packages/tightenco/takeout)
 


### PR DESCRIPTION
Adds the status of github actions to README.md.
<img width="748" alt="Screen Shot 2020-10-07 at 1 18 19 PM" src="https://user-images.githubusercontent.com/4378273/95371258-935b7980-089f-11eb-9dd8-ac7c5f5b9f24.png">