### PR TITLE
Missing Str import on EnableCommand

### DIFF
--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -4,6 +4,7 @@ namespace App\Commands;
 
 use App\InitializesCommands;
 use App\Services;
+use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
 
 class EnableCommand extends Command


### PR DESCRIPTION
HI @josecanhelp  this morning after your merge we can't build takeout because there isn't Str import on EnableCommand. 