### PR TITLE
Add menu support for native Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Takeout is a CLI tool for spinning up tiny Docker containers, one for each of your development environment dependencies.
 
-It's meant to be paired with a tool like [Laravel Valet](https://laravel.com/docs/valet). It's currently compatible with macOS, Linux, and WSL2.
+It's meant to be paired with a tool like [Laravel Valet](https://laravel.com/docs/valet). It's currently compatible with macOS, Linux, Windows 10 and WSL2.
 
 With `takeout enable mysql` you're running MySQL, and never have to worry about managing or fixing Homebrew MySQL again.
 
@@ -17,9 +17,9 @@ But you can also easily enable ElasticSearch, PostgreSQL, MSSQL, Mongo, Redis, a
 
 ## Requirements
 
-- macOS, Linux, or WSL2
+- macOS, Linux, Windows 10 or WSL2
 - [Composer](https://getcomposer.org/) installed
-- Docker installed (macOS: [Docker for Mac](https://docs.docker.com/docker-for-mac/))
+- Docker installed (macOS: [Docker for Mac](https://docs.docker.com/docker-for-mac/), Windows: [Docker for Windows](https://docs.docker.com/docker-for-windows/))
 
 ## Installation
 

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -72,11 +72,17 @@ class DisableCommand extends Command
 
                 return;
             case 1:
-                $this->disableByContainerId($serviceMatches->flip()->first());
+                $serviceContainerId = $serviceMatches->flip()->first();
                 break;
             default: // > 1
-                $this->showDisableServiceMenu($serviceMatches);
+                $serviceContainerId = $this->selectMenu($disableableServices ?? $this->disableableServices);
+
+                if (! $serviceContainerId) {
+                    return;
+                }
         }
+
+        $this->disableByContainerId($serviceContainerId);
     }
 
     public function showDisableServiceMenu($disableableServices = null): void

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -125,13 +125,19 @@ class DisableCommand extends Command
                 $this->info("\n docker volume rm {$volumeName}");
             }
 
-            if (count($this->docker->allContainers()) === 0 && in_array(PHP_OS_FAMILY, ['Darwin', 'Windows'])) {
-                $option = $this->menu('No containers are running. Turn off Docker?', [
-                    'Yes',
-                    'No',
-                ])->disableDefaultItems()->open();
+            if (count($this->docker->allContainers()) === 0 && ($this->environment->isLinuxOs() || $this->environment->isWindowsOs())) {
+                $question = 'No containers are running. Turn off Docker?';
 
-                if ($option === 0) {
+                if ($this->environment->isWindowsOs()) {
+                    $option = $this->confirm($question);
+                } else {
+                    $option = $this->menu($question, [
+                        'Yes',
+                        'No',
+                    ])->disableDefaultItems()->open();
+                }
+
+                if ($option === 0 || $option === true) {
                     $this->task('Stopping Docker service ', $this->docker->stopDockerService());
                 }
             }

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -123,7 +123,7 @@ class DisableCommand extends Command
             }
 
             if (count($this->docker->allContainers()) === 0 && in_array(PHP_OS_FAMILY, ['Darwin', 'Windows'])) {
-                $option = $this->menu('No containers are running. Turn off Docker for Mac?', [
+                $option = $this->menu('No containers are running. Turn off Docker?', [
                     'Yes',
                     'No',
                 ])->disableDefaultItems()->open();

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -77,7 +77,6 @@ class DisableCommand extends Command
     public function showDisableServiceMenu($disableableServices = null): void
     {
         if ($serviceContainerId = $this->selectMenu($disableableServices ?? $this->disableableServices)) {
-            dd($serviceContainerId);
             $this->disableByContainerId($serviceContainerId);
         }
     }

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -11,6 +11,8 @@ class DisableCommand extends Command
 {
     use InitializesCommands;
 
+    const MENU_TITLE = 'Takeout containers to disable';
+
     protected $signature = 'disable {serviceNames?*} {--all}';
     protected $description = 'Disable services.';
     protected $disableableServices;
@@ -92,7 +94,7 @@ class DisableCommand extends Command
 
     private function defaultMenu($disableableServices): ?string
     {
-        return $this->menu('Services to disable', $disableableServices)
+        return $this->menu(self::MENU_TITLE, $disableableServices)
             ->addLineBreak('', 1)
             ->setPadding(2, 5)
             ->open();
@@ -102,7 +104,7 @@ class DisableCommand extends Command
     {
         array_push($disableableServices, '<info>Exit</>');
 
-        $choice = $this->choice('What service would you like to disable?', array_values($disableableServices));
+        $choice = $this->choice(self::MENU_TITLE, array_values($disableableServices));
 
         return array_search($choice, $disableableServices);
     }

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -4,6 +4,7 @@ namespace App\Commands;
 
 use App\InitializesCommands;
 use App\Shell\Docker;
+use App\Shell\Environment;
 use LaravelZero\Framework\Commands\Command;
 use Throwable;
 
@@ -17,10 +18,12 @@ class DisableCommand extends Command
     protected $description = 'Disable services.';
     protected $disableableServices;
     protected $docker;
+    protected $environment;
 
-    public function handle(Docker $docker)
+    public function handle(Docker $docker, Environment $environment)
     {
         $this->docker = $docker;
+        $this->environment = $environment;
         $this->initializeCommand();
         $this->disableableServices = $this->disableableServices();
 
@@ -85,7 +88,7 @@ class DisableCommand extends Command
 
     private function selectMenu($disableableServices): ?string
     {
-        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+        if ($this->environment->isWindowsOs()) {
             return $this->windowsMenu($disableableServices);
         }
 

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -12,6 +12,8 @@ class EnableCommand extends Command
 {
     use InitializesCommands;
 
+    const MENU_TITLE = 'Takeout containers to enable';
+
     protected $signature = 'enable {serviceNames?*} {--default}';
     protected $description = 'Enable services.';
     protected $services;
@@ -53,7 +55,7 @@ class EnableCommand extends Command
 
     private function defaultMenu(): ?string
     {
-        $option = $this->menu('Services to enable:')->setTitleSeparator('=');
+        $option = $this->menu(self::MENU_TITLE)->setTitleSeparator('=');
 
         foreach ($this->enableableServicesByCategory() as $category => $services) {
             $separator = str_repeat('-', 1 + Str::length($category));
@@ -93,7 +95,7 @@ class EnableCommand extends Command
 
         array_push($choices, '<info>Exit</>');
 
-        $choice = $this->choice('What service would you like to enable?', $choices);
+        $choice = $this->choice(self::MENU_TITLE, $choices);
 
         if (Str::contains($choice, 'Back')) {
             return $this->windowsMenu();

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -4,6 +4,7 @@ namespace App\Commands;
 
 use App\InitializesCommands;
 use App\Services;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
 
@@ -32,28 +33,91 @@ class EnableCommand extends Command
             return;
         }
 
-        $option = $this->menu('Services to enable:')->setTitleSeparator('=');
-
-        foreach ($this->enableableServicesByCategory() as $category => $services) {
-            $menuItems = collect($services)->mapWithKeys(function ($service) {
-                return [$service['shortName'] => $service['name']];
-            })->toArray();
-
-            $separator = str_repeat('-', 1 + Str::length($category));
-
-            $option->addStaticItem("{$category}:")
-                ->addStaticItem($separator)
-                ->addOptions($menuItems)
-                ->addLineBreak('', 1);
-        }
-
-        $option = $option->open();
+        $option = $this->selectService();
 
         if (! $option) {
             return;
         }
 
         $this->enable($option, $useDefaults);
+    }
+
+    private function selectService(): ?string
+    {
+        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+            return $this->windowsMenu();
+        }
+
+        return $this->defaultMenu();
+    }
+
+    private function defaultMenu(): ?string
+    {
+        $option = $this->menu('Services to enable:')->setTitleSeparator('=');
+
+        foreach ($this->enableableServicesByCategory() as $category => $services) {
+            $separator = str_repeat('-', 1 + Str::length($category));
+
+            $option->addStaticItem("{$category}:")
+                ->addStaticItem($separator)
+                ->addOptions($this->menuItemsForServices($services))
+                ->addLineBreak('', 1);
+        }
+
+        return $option->open();
+    }
+
+    private function windowsMenu($category = null): ?string
+    {
+        $choices = [];
+        $groupedServices = $this->enableableServicesByCategory();
+
+        if ($category) {
+            $groupedServices = Arr::where($groupedServices, function ($value, $key) use ($category) {
+                return Str::contains($category, strtoupper($key));
+            });
+        }
+
+        foreach ($groupedServices as $serviceCategory => $services) {
+            array_push($choices, '<fg=white;bg=blue;options=bold> '.strtoupper($serviceCategory).' </>');
+
+            foreach ($this->menuItemsForServices($services) as $menuItemKey => $menuItemName) {
+                array_push($choices, $menuItemName);
+            }
+        }
+
+        if ($category) {
+            array_push($choices, '<info>Back</>');
+        }
+
+        array_push($choices, '<info>Exit</>');
+
+        $choice = $this->choice('What service would you like to enable?', $choices);
+
+        if (Str::contains($choice, 'Back')) {
+            return $this->windowsMenu();
+        }
+
+        if (Str::contains($choice, 'Exit')) {
+            $this->info('Action cancelled!');
+
+            return null;
+        }
+
+        foreach ($this->enableableServices() as $shortName => $fqcn) {
+            if ($choice === $fqcn) {
+                return $shortName;
+            }
+        }
+
+        return $this->windowsMenu($choice);
+    }
+
+    private function menuItemsForServices($services): array
+    {
+        return collect($services)->mapWithKeys(function ($service) {
+            return [$service['shortName'] => $service['name']];
+        })->toArray();
     }
 
     public function enableableServices(): array

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -4,6 +4,7 @@ namespace App\Commands;
 
 use App\InitializesCommands;
 use App\Services;
+use App\Shell\Environment;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
@@ -46,7 +47,7 @@ class EnableCommand extends Command
 
     private function selectService(): ?string
     {
-        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+        if ($this->environment->isWindowsOs()) {
             return $this->windowsMenu();
         }
 

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -79,7 +79,8 @@ class EnableCommand extends Command
         }
 
         foreach ($groupedServices as $serviceCategory => $services) {
-            array_push($choices, '<fg=white;bg=blue;options=bold> '.strtoupper($serviceCategory).' </>');
+            $serviceCategoryMenuItem = '<fg=white;bg=blue;options=bold> ' . (Str::upper($serviceCategory)) . ' </>';
+            array_push($choices, $serviceCategoryMenuItem);
 
             foreach ($this->menuItemsForServices($services) as $menuItemKey => $menuItemName) {
                 array_push($choices, $menuItemName);

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -100,8 +100,6 @@ class EnableCommand extends Command
         }
 
         if (Str::contains($choice, 'Exit')) {
-            $this->info('Action cancelled!');
-
             return null;
         }
 

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -17,10 +17,12 @@ class EnableCommand extends Command
 
     protected $signature = 'enable {serviceNames?*} {--default}';
     protected $description = 'Enable services.';
+    protected $environment;
     protected $services;
 
-    public function handle(Services $services): void
+    public function handle(Environment $environment, Services $services): void
     {
+        $this->environment = $environment;
         $this->services = $services;
         $this->initializeCommand();
 

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -13,6 +13,8 @@ class StartCommand extends Command
 {
     use InitializesCommands;
 
+    const MENU_TITLE = 'Takeout containers to start';
+
     protected $signature = 'start {containerId?}';
     protected $description = 'Start a stopped container.';
     protected $docker;
@@ -73,7 +75,7 @@ class StartCommand extends Command
 
     private function defaultMenu($startableContainers)
     {
-        $this->menu('Takeout containers to start')
+        $this->menu(self::MENU_TITLE)
             ->addItems($startableContainers)
             ->addLineBreak('', 1)
             ->open();
@@ -91,7 +93,7 @@ class StartCommand extends Command
         });
         array_push($choices, '<info>Exit</>');
 
-        $choice = $this->choice('Takeout containers to start', array_values($choices));
+        $choice = $this->choice(self::MENU_TITLE, array_values($choices));
 
         if (Str::contains($choice, 'Exit')) {
             return;

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -19,10 +19,12 @@ class StartCommand extends Command
     protected $signature = 'start {containerId?}';
     protected $description = 'Start a stopped container.';
     protected $docker;
+    protected $environment;
 
-    public function handle(Docker $docker): void
+    public function handle(Docker $docker, Environment $environment): void
     {
         $this->docker = $docker;
+        $this->environment = $environment;
         $this->initializeCommand();
 
         $container = $this->argument('containerId');

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -4,6 +4,7 @@ namespace App\Commands;
 
 use App\InitializesCommands;
 use App\Shell\Docker;
+use App\Shell\Environment;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
@@ -64,7 +65,7 @@ class StartCommand extends Command
 
     private function loadMenu($startableContainers): void
     {
-        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+        if ($this->environment->isWindowsOs()) {
             $this->windowsMenu($startableContainers);
 
             return;
@@ -108,7 +109,7 @@ class StartCommand extends Command
 
     private function loadMenuItem($container, $label): callable
     {
-        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+        if ($this->environment->isWindowsOs()) {
             return $this->windowsMenuItem($container, $label);
         }
 

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -100,11 +100,11 @@ class StartCommand extends Command
             return;
         }
 
-        $startableContainers = Arr::where($startableContainers, function ($value, $key) use ($choice) {
+        $chosenStartableContainer = Arr::where($startableContainers, function ($value, $key) use ($choice) {
             return $value[0] === $choice;
         });
 
-        call_user_func(array_values($startableContainers)[0][1]);
+        call_user_func(array_values($chosenStartableContainer)[0][1]);
     }
 
     private function loadMenuItem($container, $label): callable

--- a/app/Commands/StopCommand.php
+++ b/app/Commands/StopCommand.php
@@ -13,6 +13,8 @@ class StopCommand extends Command
 {
     use InitializesCommands;
 
+    const MENU_TITLE = 'Takeout containers to stop';
+
     protected $signature = 'stop {containerId?}';
     protected $description = 'Stop a service.';
     protected $docker;
@@ -73,7 +75,7 @@ class StopCommand extends Command
 
     private function defaultMenu($stoppableContainers)
     {
-        $this->menu('Takeout containers to stop')
+        $this->menu(self::MENU_TITLE)
             ->addItems($stoppableContainers)
             ->addLineBreak('', 1)
             ->open();
@@ -91,7 +93,7 @@ class StopCommand extends Command
         });
         array_push($choices, '<info>Exit</>');
 
-        $choice = $this->choice('Takeout containers to stop', array_values($choices));
+        $choice = $this->choice(self::MENU_TITLE, array_values($choices));
 
         if (Str::contains($choice, 'Exit')) {
             return;

--- a/app/Commands/StopCommand.php
+++ b/app/Commands/StopCommand.php
@@ -19,10 +19,12 @@ class StopCommand extends Command
     protected $signature = 'stop {containerId?}';
     protected $description = 'Stop a service.';
     protected $docker;
+    protected $environment;
 
-    public function handle(Docker $docker): void
+    public function handle(Docker $docker, Environment $environment): void
     {
         $this->docker = $docker;
+        $this->environment = $environment;
         $this->initializeCommand();
 
         $container = $this->argument('containerId');

--- a/app/Commands/StopCommand.php
+++ b/app/Commands/StopCommand.php
@@ -100,11 +100,11 @@ class StopCommand extends Command
             return;
         }
 
-        $stoppableContainer = Arr::where($stoppableContainers, function ($value, $key) use ($choice) {
+        $chosenStoppableContainer = Arr::where($stoppableContainers, function ($value, $key) use ($choice) {
             return $value[0] === $choice;
         });
 
-        call_user_func(array_values($stoppableContainer)[0][1]);
+        call_user_func(array_values($chosenStoppableContainer)[0][1]);
     }
 
     private function loadMenuItem($container, $label): callable

--- a/app/Commands/StopCommand.php
+++ b/app/Commands/StopCommand.php
@@ -4,6 +4,7 @@ namespace App\Commands;
 
 use App\InitializesCommands;
 use App\Shell\Docker;
+use App\Shell\Environment;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
@@ -64,7 +65,7 @@ class StopCommand extends Command
 
     private function loadMenu($stoppableContainers): void
     {
-        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+        if ($this->environment->isWindowsOs()) {
             $this->windowsMenu($stoppableContainers);
 
             return;
@@ -108,7 +109,7 @@ class StopCommand extends Command
 
     private function loadMenuItem($container, $label): callable
     {
-        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+        if ($this->environment->isWindowsOs()) {
             return $this->windowsMenuItem($container, $label);
         }
 

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -67,6 +67,15 @@ abstract class BaseService
         return static::$displayName ?? Str::afterLast(static::class, '\\');
     }
 
+    private function validateDockerRunTemplate($dockerRunTemplate): string
+    {
+        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+            return stripslashes($dockerRunTemplate);
+        }
+
+        return $dockerRunTemplate;
+    }
+
     public function enable(bool $useDefaults = false): void
     {
         $this->useDefaults = $useDefaults;
@@ -79,13 +88,13 @@ abstract class BaseService
 
         try {
             $this->docker->bootContainer(
-                $this->dockerRunTemplate,
+                $this->validateDockerRunTemplate($this->dockerRunTemplate),
                 $this->buildParameters()
             );
 
             $this->info("\nService enabled!");
         } catch (Throwable $e) {
-            $this->error("\n" . $e->getMessage());
+            $this->error("\n".$e->getMessage());
         }
     }
 
@@ -208,6 +217,6 @@ abstract class BaseService
             }
         }
 
-        return 'TO--' . $this->shortName() . '--' . $this->tag . $portTag;
+        return 'TO--'.$this->shortName().'--'.$this->tag.$portTag;
     }
 }

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -67,15 +67,6 @@ abstract class BaseService
         return static::$displayName ?? Str::afterLast(static::class, '\\');
     }
 
-    private function validateDockerRunTemplate($dockerRunTemplate): string
-    {
-        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
-            return stripslashes($dockerRunTemplate);
-        }
-
-        return $dockerRunTemplate;
-    }
-
     public function enable(bool $useDefaults = false): void
     {
         $this->useDefaults = $useDefaults;
@@ -94,7 +85,7 @@ abstract class BaseService
 
             $this->info("\nService enabled!");
         } catch (Throwable $e) {
-            $this->error("\n".$e->getMessage());
+            $this->error("\n" . $e->getMessage());
         }
     }
 
@@ -217,6 +208,15 @@ abstract class BaseService
             }
         }
 
-        return 'TO--'.$this->shortName().'--'.$this->tag.$portTag;
+        return 'TO--' . $this->shortName() . '--' . $this->tag . $portTag;
+    }
+
+    private function validateDockerRunTemplate($dockerRunTemplate): string
+    {
+        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+            return stripslashes($dockerRunTemplate);
+        }
+
+        return $dockerRunTemplate;
     }
 }

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -211,7 +211,7 @@ abstract class BaseService
         return 'TO--' . $this->shortName() . '--' . $this->tag . $portTag;
     }
 
-    private function validateDockerRunTemplate($dockerRunTemplate): string
+    public function validateDockerRunTemplate($dockerRunTemplate): string
     {
         if (in_array(PHP_OS_FAMILY, ['Windows'])) {
             return stripslashes($dockerRunTemplate);

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -79,7 +79,7 @@ abstract class BaseService
 
         try {
             $this->docker->bootContainer(
-                $this->validateDockerRunTemplate($this->dockerRunTemplate),
+                $this->sanitizeDockerRunTemplate($this->dockerRunTemplate),
                 $this->buildParameters()
             );
 
@@ -211,7 +211,7 @@ abstract class BaseService
         return 'TO--' . $this->shortName() . '--' . $this->tag . $portTag;
     }
 
-    public function validateDockerRunTemplate($dockerRunTemplate): string
+    public function sanitizeDockerRunTemplate($dockerRunTemplate): string
     {
         if ($this->environment->isWindowsOs()) {
             return stripslashes($dockerRunTemplate);

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -213,7 +213,7 @@ abstract class BaseService
 
     public function validateDockerRunTemplate($dockerRunTemplate): string
     {
-        if (in_array(PHP_OS_FAMILY, ['Windows'])) {
+        if ($this->environment->isWindowsOs()) {
             return stripslashes($dockerRunTemplate);
         }
 

--- a/app/Shell/Docker.php
+++ b/app/Shell/Docker.php
@@ -95,9 +95,9 @@ class Docker
     public function takeoutContainers(): Collection
     {
         $process = sprintf(
-            "docker ps -a --filter 'name=TO-' --format 'table %s|%s'",
+            'docker ps -a --filter "name=TO-" --format "table %s|%s"',
             '{{.ID}}|{{.Names}}|{{.Status}}|{{.Ports}}',
-            '{{.Label "com.tighten.takeout.Base_Alias"}}|{{.Label "com.tighten.takeout.Full_Alias"}}'
+            '{{.Label \"com.tighten.takeout.Base_Alias\"}}|{{.Label \"com.tighten.takeout.Full_Alias\"}}'
         );
 
         return $this->runAndParseTable($process);

--- a/app/Shell/DockerFormatter.php
+++ b/app/Shell/DockerFormatter.php
@@ -8,7 +8,7 @@ class DockerFormatter
 {
     /**
      * Given the raw string of output from Docker, return a collection of
-     * associative arrays, with the keys lowercased and slugged using underscores
+     * associative arrays, with the keys lowercased and slugged using underscores.
      *
      * @param string $output Docker command output
      * @return Collection     Collection of associative arrays

--- a/app/Shell/Environment.php
+++ b/app/Shell/Environment.php
@@ -18,6 +18,11 @@ class Environment
         return PHP_OS_FAMILY === 'Linux';
     }
 
+    public function isWindowsOs(): bool
+    {
+        return PHP_OS_FAMILY === 'Windows';
+    }
+
     public function portIsAvailable($port): bool
     {
         // E.g. Win/Linux: 127.0.0.1:3306 , macOS: 127.0.0.1.3306

--- a/tests/Feature/BaseServiceTest.php
+++ b/tests/Feature/BaseServiceTest.php
@@ -47,7 +47,7 @@ class BaseServiceTest extends TestCase
 
             // This is the actual assertion
             $mock->shouldReceive('bootContainer')->with(
-                $service->dockerRunTemplate(),
+                $service->validateDockerRunTemplate($service->dockerRunTemplate()),
                 [
                     'organization' => 'getmeili',
                     'image_name' => 'meilisearch',

--- a/tests/Feature/BaseServiceTest.php
+++ b/tests/Feature/BaseServiceTest.php
@@ -47,7 +47,7 @@ class BaseServiceTest extends TestCase
 
             // This is the actual assertion
             $mock->shouldReceive('bootContainer')->with(
-                $service->validateDockerRunTemplate($service->dockerRunTemplate()),
+                $service->sanitizeDockerRunTemplate($service->dockerRunTemplate()),
                 [
                     'organization' => 'getmeili',
                     'image_name' => 'meilisearch',

--- a/tests/Feature/DisableCommandTest.php
+++ b/tests/Feature/DisableCommandTest.php
@@ -61,7 +61,7 @@ class DisableCommandTest extends TestCase
             Command::macro(
                 'menu',
                 function (string $title, array $options) use ($services, $menuMock) {
-                    Assert::assertEquals('Services to disable', $title);
+                    Assert::assertEquals('Takeout containers to disable', $title);
                     Assert::assertEquals(
                         $services->mapWithKeys(function ($container) {
                             return [$container['container_id'] => $container['names']];

--- a/tests/Feature/DisableCommandTest.php
+++ b/tests/Feature/DisableCommandTest.php
@@ -194,7 +194,7 @@ class DisableCommandTest extends TestCase
             $mock->shouldReceive('removeContainer')
                 ->with($postgressId)->once();
 
-            $mock->shouldReceive('allContainers')->andReturn(new Collection())->once();
+            $mock->shouldReceive('allContainers')->andReturn(new Collection)->once();
             $mock->shouldReceive('stopDockerService')->once();
         });
 

--- a/tests/Feature/DisableCommandTest.php
+++ b/tests/Feature/DisableCommandTest.php
@@ -35,6 +35,7 @@ class DisableCommandTest extends TestCase
             $mock->shouldReceive('isInstalled')->andReturn(true);
             $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
             $mock->shouldReceive('takeoutContainers')->andReturn($services);
+
             $mock->shouldReceive('attachedVolumeName')
                 ->with($postgressId)->andReturnNull()->once();
             $mock->shouldReceive('removeContainer')

--- a/tests/Feature/EnableCommandTest.php
+++ b/tests/Feature/EnableCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Exceptions\InvalidServiceShortnameException;
+use App\Services;
 use App\Services\MeiliSearch;
 use App\Services\PostgreSql;
 use App\Shell\Docker;
@@ -23,10 +24,7 @@ class EnableCommandTest extends TestCase
         return PHP_OS_FAMILY === 'Linux';
     }
 
-    /** @test
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    /** @test */
     function it_can_enable_a_service_from_menu()
     {
         $services = [
@@ -42,12 +40,12 @@ class EnableCommandTest extends TestCase
             '<info>Exit</>',
         ];
 
-        $this->mock('overload:App\Shell\Docker', function ($mock) {
+        $this->mock(Docker::class, function ($mock) {
             $mock->shouldReceive('isInstalled')->andReturn(true);
             $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
         });
 
-        $this->mock('overload:App\Services', function ($mock) use ($services, $fqcn) {
+        $this->mock(Services::class, function ($mock) use ($services, $fqcn) {
             $mock->shouldReceive('all')->andReturn($services);
             $mock->shouldReceive('get')->andReturn($fqcn);
         });
@@ -82,10 +80,7 @@ class EnableCommandTest extends TestCase
         }
     }
 
-    /** @test
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
+    /** @test */
     function it_can_navigate_a_submenu_in_windows()
     {
         if ($this->isWindows()) {
@@ -109,7 +104,7 @@ class EnableCommandTest extends TestCase
                 '<info>Exit</>',
             ];
 
-            $this->mock('overload:App\Services', function ($mock) use ($services) {
+            $this->mock(Services::class, function ($mock) use ($services) {
                 $mock->shouldReceive('all')->andReturn($services);
             });
 

--- a/tests/Feature/EnableCommandTest.php
+++ b/tests/Feature/EnableCommandTest.php
@@ -6,10 +6,123 @@ use App\Exceptions\InvalidServiceShortnameException;
 use App\Services\MeiliSearch;
 use App\Services\PostgreSql;
 use App\Shell\Docker;
+use Illuminate\Console\Command;
+use NunoMaduro\LaravelConsoleMenu\Menu;
+use PHPUnit\Framework\Assert;
 use Tests\TestCase;
 
 class EnableCommandTest extends TestCase
 {
+    function isWindows()
+    {
+        return PHP_OS_FAMILY === 'Windows';
+    }
+
+    function isLinux()
+    {
+        return PHP_OS_FAMILY === 'Linux';
+    }
+
+    /** @test
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    function it_can_enable_a_service_from_menu()
+    {
+        $services = [
+            'meilisearch' => 'App\Services\MeiliSearch',
+            $postgres = 'postgresql' => $fqcn = 'App\Services\PostgreSql',
+        ];
+
+        $menuItems = [
+            '<fg=white;bg=blue;options=bold> DATABASE </>',
+            'PostgreSQL',
+            '<fg=white;bg=blue;options=bold> SEARCH </>',
+            'MeiliSearch',
+            '<info>Exit</>',
+        ];
+
+        $this->mock('overload:App\Shell\Docker', function ($mock) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+        });
+
+        $this->mock('overload:App\Services', function ($mock) use ($services, $fqcn) {
+            $mock->shouldReceive('all')->andReturn($services);
+            $mock->shouldReceive('get')->andReturn($fqcn);
+        });
+
+        $this->mock(PostgreSql::class, function ($mock) {
+            $mock->shouldReceive('enable')->once();
+        });
+
+        if ($this->isWindows()) {
+            $this->artisan('enable')
+                ->expectsChoice('Takeout containers to enable', 'PostgreSQL', $menuItems)
+                ->assertExitCode(0);
+        } else {
+            $menuMock = $this->mock(Menu::class, function ($mock) use ($postgres) {
+                $mock->shouldReceive('setTitleSeparator')->andReturnSelf();
+                $mock->shouldReceive('addStaticItem')->andReturnSelf()->times(4);
+                $mock->shouldReceive('addOptions')->andReturnSelf();
+                $mock->shouldReceive('addLineBreak')->andReturnSelf();
+                $mock->shouldReceive('open')->andReturn($postgres)->once();
+            });
+
+            Command::macro(
+                'menu',
+                function (string $title) use ($menuMock) {
+                    Assert::assertEquals('Takeout containers to enable', $title);
+
+                    return $menuMock;
+                }
+            );
+
+            $this->artisan('enable');
+        }
+    }
+
+    /** @test
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    function it_can_navigate_a_submenu_in_windows()
+    {
+        if ($this->isWindows()) {
+            $services = [
+                'meilisearch' => 'App\Services\MeiliSearch',
+                'postgresql' => 'App\Services\PostgreSql',
+            ];
+
+            $menuItems = [
+                $category = '<fg=white;bg=blue;options=bold> DATABASE </>',
+                'PostgreSQL',
+                '<fg=white;bg=blue;options=bold> SEARCH </>',
+                'MeiliSearch',
+                $exit = '<info>Exit</>',
+            ];
+
+            $submenuItems = [
+                '<fg=white;bg=blue;options=bold> DATABASE </>',
+                'PostgreSQL',
+                $back = '<info>Back</>',
+                '<info>Exit</>',
+            ];
+
+            $this->mock('overload:App\Services', function ($mock) use ($services) {
+                $mock->shouldReceive('all')->andReturn($services);
+            });
+
+            $this->artisan('enable')
+                    ->expectsChoice('Takeout containers to enable', $category, $menuItems)
+                    ->expectsChoice('Takeout containers to enable', $back, $submenuItems)
+                    ->expectsChoice('Takeout containers to enable', $exit, $menuItems)
+                    ->assertExitCode(0);
+        } else {
+            $this->assertTrue(true);
+        }
+    }
+
     /** @test */
     function it_finds_services_by_shortname()
     {

--- a/tests/Feature/StartCommandTest.php
+++ b/tests/Feature/StartCommandTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Shell\Docker;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use NunoMaduro\LaravelConsoleMenu\Menu;
+use PHPUnit\Framework\Assert;
+use Tests\TestCase;
+
+class StartCommandTest extends TestCase
+{
+    function isWindows()
+    {
+        return PHP_OS_FAMILY === 'Windows';
+    }
+
+    function isLinux()
+    {
+        return PHP_OS_FAMILY === 'Linux';
+    }
+
+    /** @test */
+    function it_can_start_a_service_from_menu()
+    {
+        $services = Collection::make([
+            [
+            'container_id' => $containerId = '12345',
+            'names' => $containerName = 'TO--mysql--8.0.22--3306',
+            'status' => 'Exited (0) 8 days ago',
+            'ports' => '',
+            'base_alias' => 'mysql',
+            'full_alias' => 'mysql8.0',
+            ],
+        ]);
+
+        $menuItems = [
+            $mysql = $containerId . ' - ' . $containerName,
+            '<info>Exit</>',
+        ];
+
+        $this->mock(Docker::class, function ($mock) use ($services, $containerId) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+            $mock->shouldReceive('startableTakeoutContainers')->andReturn($services, new Collection);
+            $mock->shouldReceive('startContainer')->with($containerId);
+        });
+
+        if ($this->isWindows()) {
+            $this->artisan('start')
+                ->expectsChoice('Takeout containers to start', $mysql, $menuItems)
+                ->assertExitCode(0);
+        } else {
+            $menuMock = $this->mock(Menu::class, function ($mock) use ($mysql) {
+                $mock->shouldReceive('setTitleSeparator')->andReturnSelf();
+                $mock->shouldReceive('addItems')->andReturnSelf();
+                $mock->shouldReceive('addLineBreak')->andReturnSelf();
+                $mock->shouldReceive('open')->andReturn($mysql)->once();
+            });
+
+            Command::macro(
+                'menu',
+                function (string $title) use ($menuMock) {
+                    Assert::assertEquals('Takeout containers to start', $title);
+
+                    return $menuMock;
+                }
+            );
+
+            $this->artisan('start');
+        }
+    }
+}

--- a/tests/Feature/StopCommandTest.php
+++ b/tests/Feature/StopCommandTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Shell\Docker;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use NunoMaduro\LaravelConsoleMenu\Menu;
+use PHPUnit\Framework\Assert;
+use Tests\TestCase;
+
+class StopCommandTest extends TestCase
+{
+    function isWindows()
+    {
+        return PHP_OS_FAMILY === 'Windows';
+    }
+
+    function isLinux()
+    {
+        return PHP_OS_FAMILY === 'Linux';
+    }
+
+    /** @test */
+    function it_can_stop_a_service_from_menu()
+    {
+        $services = Collection::make([
+            [
+            'container_id' => $containerId = '12345',
+            'names' => $containerName = 'TO--mysql--8.0.22--3306',
+            'status' => 'Up 27 minutes',
+            'ports' => '0.0.0.0:3306->3306/tcp, 33060/tcp',
+            'base_alias' => 'mysql',
+            'full_alias' => 'mysql8.0',
+            ],
+        ]);
+
+        $menuItems = [
+            $mysql = $containerId . ' - ' . $containerName,
+            '<info>Exit</>',
+        ];
+
+        $this->mock(Docker::class, function ($mock) use ($services, $containerId) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+            $mock->shouldReceive('stoppableTakeoutContainers')->andReturn($services, new Collection);
+            $mock->shouldReceive('stopContainer')->with($containerId);
+        });
+
+        if ($this->isWindows()) {
+            $this->artisan('stop')
+                ->expectsChoice('Takeout containers to stop', $mysql, $menuItems)
+                ->assertExitCode(0);
+        } else {
+            $menuMock = $this->mock(Menu::class, function ($mock) use ($mysql) {
+                $mock->shouldReceive('setTitleSeparator')->andReturnSelf();
+                $mock->shouldReceive('addItems')->andReturnSelf();
+                $mock->shouldReceive('addLineBreak')->andReturnSelf();
+                $mock->shouldReceive('open')->andReturn($mysql)->once();
+            });
+
+            Command::macro(
+                'menu',
+                function (string $title) use ($menuMock, $services) {
+                    Assert::assertEquals('Takeout containers to stop', $title);
+
+                    return $menuMock;
+                }
+            );
+
+            $this->artisan('stop');
+        }
+    }
+}


### PR DESCRIPTION
References #146

I made a comment in the issue referenced above that gives a fairly detailed outline of changes made.  Please review that and my code and let me know what you would like for me to adjust.  I am sure there are probably better ways to code some of the array items.  Also, I extracted some code into private method where I thought it made sense.  Hopefully it readable.

I have manually tested all of the menus in native Windows 10.  I also manually tested the default menu system from the WSL prompt just to be sure my refactoring didn't break anything.  

I was reviewing the tests and noticed the default menu UI is not currently tested.  I think I could probably write a OS specific test to test the Windows menu.  Let me know if you want that to be included in this PR or just make a that a new PR.

Thanks!