### PR TITLE
Add Expose service

### DIFF
--- a/app/Services/Category.php
+++ b/app/Services/Category.php
@@ -9,4 +9,5 @@ abstract class Category
     const MAIL = 'Mail';
     const SEARCH = 'Search';
     const STORAGE = 'Storage';
+    const TOOLS = 'Tools';
 }

--- a/app/Services/Expose.php
+++ b/app/Services/Expose.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services;
+
+class Expose extends BaseService
+{
+    protected static $category = Category::TOOLS;
+
+    protected $organization = 'beyondcodegmbh';
+    protected $imageName = 'expose-server';
+    protected $defaultPort = 8080;
+    protected $prompts = [
+        [
+            'shortname' => 'domain',
+            'prompt' => 'What is the domain?',
+            'default' => 'example.com',
+        ],
+        [
+            'shortname' => 'volume',
+            'prompt' => 'What is the Docker volume name?',
+            'default' => 'expose_data',
+        ],
+        [
+            'shortname' => 'username',
+            'prompt' => 'What is the username?',
+            'default' => 'username',
+        ],
+        [
+            'shortname' => 'password',
+            'prompt' => 'What is the password?',
+            'default' => 'password',
+        ],
+    ];
+
+
+    protected $dockerRunTemplate = '-p "${:port}":8080 \
+        -v "${:volume}":/root/.expose \
+        -e username="${:username}" \
+        -e password="${:password}" \
+        -e domain="${:domain}" \
+        "${:organization}"/"${:image_name}":"${:tag}"';
+}

--- a/app/Services/Expose.php
+++ b/app/Services/Expose.php
@@ -32,7 +32,6 @@ class Expose extends BaseService
         ],
     ];
 
-
     protected $dockerRunTemplate = '-p "${:port}":8080 \
         -v "${:volume}":/root/.expose \
         -e username="${:username}" \


### PR DESCRIPTION
Add Expose server support.

Adds a new category "Tools" to the `enable` menu.

Requires some external setup to get fully working:

- Wildcard DNS entry for Expose domain
- Reverse proxy or port forward to host from which takeout is running

Additional info in issue #166 