### PR TITLE
Add SFTP server support

### DIFF
--- a/app/Services/Sftp.php
+++ b/app/Services/Sftp.php
@@ -57,7 +57,8 @@ class Sftp extends BaseService
         }, $this->defaultPrompts);
     }
 
-    protected function prompts(): void {
+    protected function prompts(): void
+    {
         parent::prompts();
 
         if($this->promptResponses['mapped_directory'] !== "") {

--- a/app/Services/Sftp.php
+++ b/app/Services/Sftp.php
@@ -2,11 +2,11 @@
 
 namespace App\Services;
 
-use App\Shell\Shell;
-use App\Shell\Docker;
-use App\Services\Category;
-use App\Shell\Environment;
 use App\Services\BaseService;
+use App\Services\Category;
+use App\Shell\Docker;
+use App\Shell\Environment;
+use App\Shell\Shell;
 
 class Sftp extends BaseService
 {
@@ -36,7 +36,7 @@ class Sftp extends BaseService
             'shortname' => 'mapped_directory',
             'prompt' => 'Which local directory should be mapped inside? (nothing if null)',
             'default' => '',
-        ]
+        ],
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":22 \

--- a/app/Services/Sftp.php
+++ b/app/Services/Sftp.php
@@ -45,7 +45,8 @@ class Sftp extends BaseService
 
     protected static $displayName = 'SFTP';
 
-    public function __construct(Shell $shell, Environment $environment, Docker $docker) {
+    public function __construct(Shell $shell, Environment $environment, Docker $docker)
+    {
         parent::__construct($shell, $environment, $docker);
 
         $this->defaultPrompts = array_map(function ($prompt) {
@@ -61,7 +62,7 @@ class Sftp extends BaseService
     {
         parent::prompts();
 
-        if($this->promptResponses['mapped_directory'] !== "") {
+        if ($this->promptResponses['mapped_directory'] !== "") {
             $this->dockerRunTemplate = '-v "${:local_mapping}" ' . $this->dockerRunTemplate;
         }
     }
@@ -70,11 +71,13 @@ class Sftp extends BaseService
     {
         $parameters = parent::buildParameters();
 
-        if($parameters['mapped_directory'] !== "") {
-            $parameters['local_mapping'] = trim($parameters['mapped_directory'], ' ') . ':/home/' . $parameters['user_name'] . '/' . $parameters['upload_directory'];
+        if ($parameters['mapped_directory'] !== "") {
+            $parameters['local_mapping'] = trim($parameters['mapped_directory'], ' ') . ':/home/'
+            . $parameters['user_name'] . '/' . $parameters['upload_directory'];
             $parameters['user_config'] = $parameters['user_name'] . ':' . $parameters['password'] . ':1001';
         } else {
-            $parameters['user_config'] = $parameters['user_name'] . ':' . $parameters['password'] . ':::' . $parameters["upload_directory"];
+            $parameters['user_config'] = $parameters['user_name'] . ':' . $parameters['password']
+            . ':::' . $parameters["upload_directory"];
         }
 
         return $parameters;

--- a/app/Services/Sftp.php
+++ b/app/Services/Sftp.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Services;
+
+use App\Shell\Shell;
+use App\Shell\Docker;
+use App\Services\Category;
+use App\Shell\Environment;
+use App\Services\BaseService;
+
+class Sftp extends BaseService
+{
+    protected static $category = Category::STORAGE;
+
+    protected $organization = 'atmoz';
+    protected $imageName = 'sftp';
+    protected $defaultPort = 22;
+    protected $tag = 'alpine';
+    protected $prompts = [
+        [
+            'shortname' => 'user_name',
+            'prompt' => 'What will the default username be?',
+            'default' => 'foo',
+        ],
+        [
+            'shortname' => 'password',
+            'prompt' => 'What will the default password be?',
+            'default' => 'pass',
+        ],
+        [
+            'shortname' => 'upload_directory',
+            'prompt' => 'Where will files be uploaded?',
+            'default' => 'upload',
+        ],
+        [
+            'shortname' => 'mapped_directory',
+            'prompt' => 'Which local directory should be mapped inside? (nothing if null)',
+            'default' => '',
+        ]
+    ];
+
+    protected $dockerRunTemplate = '-p "${:port}":22 \
+        "${:organization}"/"${:image_name}":"${:tag}" \
+        "${:user_config}"';
+
+    protected static $displayName = 'SFTP';
+
+    public function __construct(Shell $shell, Environment $environment, Docker $docker) {
+        parent::__construct($shell, $environment, $docker);
+
+        $this->defaultPrompts = array_map(function ($prompt) {
+            if ($prompt['shortname'] === 'tag') {
+                $prompt['default'] = $this->tag;
+            }
+
+            return $prompt;
+        }, $this->defaultPrompts);
+    }
+
+    protected function prompts(): void {
+        parent::prompts();
+
+        if($this->promptResponses['mapped_directory'] !== "") {
+            $this->dockerRunTemplate = '-v "${:local_mapping}" ' . $this->dockerRunTemplate;
+        }
+    }
+
+    protected function buildParameters(): array
+    {
+        $parameters = parent::buildParameters();
+
+        if($parameters['mapped_directory'] !== "") {
+            $parameters['local_mapping'] = trim($parameters['mapped_directory'], ' ') . ':/home/' . $parameters['user_name'] . '/' . $parameters['upload_directory'];
+            $parameters['user_config'] = $parameters['user_name'] . ':' . $parameters['password'] . ':1001';
+        } else {
+            $parameters['user_config'] = $parameters['user_name'] . ':' . $parameters['password'] . ':::' . $parameters["upload_directory"];
+        }
+
+        return $parameters;
+    }
+}


### PR DESCRIPTION
Adds SFTP server support.  Does not allow direct outside communication on it's own but this could be accomplished via firewall policies/port forwarding.

Allows mapping of a local directory, a volume, or neither, via a prompt.  Related to #165 