### PR TITLE
Use more specific term for interface and rename types file

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,7 @@
 import {Command, flags} from '@oclif/command'
 import {cli} from 'cli-ux'
 import Docker from '../shell/docker'
-import {Container} from '../misc/interfaces'
+import {DockerContainer} from '../types'
 
 export default class List extends Command {
   static description = 'List the Takeout-enabled containers.'
@@ -12,7 +12,7 @@ export default class List extends Command {
   }
 
   listAsJson() {
-    this.log(JSON.stringify(Docker.listTakeoutContainers().map((container: Container) => {
+    this.log(JSON.stringify(Docker.listTakeoutContainers().map((container: DockerContainer) => {
       return {
         id: container.ID,
         name: container.Names,

--- a/src/misc/interfaces.ts
+++ b/src/misc/interfaces.ts
@@ -1,4 +1,0 @@
-export interface Container {
-  ID: string;
-  Names: string;
-}

--- a/src/shell/docker.ts
+++ b/src/shell/docker.ts
@@ -1,9 +1,9 @@
 import {runAndParseAsJson} from './shell'
-import {Container} from '../misc/interfaces'
+import {DockerContainer} from '../types'
 import {execSync} from 'child_process'
 
 export default class Docker {
-  static listTakeoutContainers(): Array<Container> {
+  static listTakeoutContainers(): DockerContainer[] {
     return runAndParseAsJson("docker ps -a --filter 'name=TO-' --format '{{ json . }}' --all")
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export interface DockerContainer {
+  ID: string;
+  Names: string;
+}


### PR DESCRIPTION
Typescript convention uses `types.ts` to store interfaces.
I thought using `DockerContainer` instead of `Container` would make our code more easily readable.