### PR TITLE
Add --all in start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Passed the container ID of stopped container, start the stopped container which 
 takeout start {container_id}
 ```
 
+### Start all containers
+
+You may pass the `-all` flag to start all enabled containers.
+```bash
+takeout start --all
+```
+
 ### Stop a running container
 
 Show a list of all running containers you can stop.

--- a/app/Commands/HelpCommand.php
+++ b/app/Commands/HelpCommand.php
@@ -14,7 +14,7 @@ class HelpCommand extends Command
         'enable {service}' => 'Enable the provided service (optionally pass --default flag)',
         'disable' => 'Disable a service from a list of options (optionally pass --all flag)',
         'disable {service}' => 'Disable the provided service',
-        'start' => 'Start a stopped container from a list of options',
+        'start' => 'Start a stopped container from a list of options (optionally pass --all flag)',
         'start {container}' => 'Start the provided stopped container (by ID)',
         'stop' => 'Stop a running container from a list of options',
         'stop {container}' => 'Stop the provided running container (by ID)',

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -19,10 +19,12 @@ class StartCommand extends Command
     {
         $this->initializeCommand();
 
-        $container = $this->argument('containerId');
+        $containers = $this->argument('containerId');
 
-        if ($container) {
-            $this->start($container);
+        if ($containers) {
+            foreach ($containers as $container) {
+                $this->start($container);
+            }
 
             return;
         }

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -12,7 +12,7 @@ class StartCommand extends Command
 {
     use InitializesCommands;
 
-    protected $signature = 'start {containerId?}';
+    protected $signature = 'start {containerId?*} {--all}';
     protected $description = 'Start a stopped container.';
 
     public function handle(): void
@@ -24,6 +24,13 @@ class StartCommand extends Command
         if ($container) {
             $this->start($container);
 
+            return;
+        }
+
+        if ($this->option('all')) {
+            foreach (app(Docker::class)->startableTakeoutContainers() as $startableContainer) {
+                $this->start($startableContainer['container_id']);
+            }
             return;
         }
 


### PR DESCRIPTION
This will allow us to start all containers at once without pressing enter 5 times or even add it to our .bash_profile so that they start automatically when opening the command line.