### PR TITLE
Add RabbitMQ service

### DIFF
--- a/app/Services/RabbitMQ.php
+++ b/app/Services/RabbitMQ.php
@@ -8,6 +8,18 @@ class RabbitMQ extends BaseService
 
     protected $imageName = 'rabbitmq';
     protected $defaultPort = 5672;
+    protected $defaultPrompts = [
+        [
+            'shortname' => 'port',
+            'prompt' => 'Which host port would you like %s to use?',
+            // Default is set in the constructor
+        ],
+        [
+            'shortname' => 'tag',
+            'prompt' => 'Which tag (version) of %s would you like to use?',
+            'default' => 'management',
+        ],
+    ];
     protected $prompts = [
         [
             'shortname' => 'hostname',

--- a/app/Services/RabbitMQ.php
+++ b/app/Services/RabbitMQ.php
@@ -24,12 +24,12 @@ class RabbitMQ extends BaseService
         [
             'shortname' => 'hostname',
             'prompt' => 'Which hostname would you like %s to use?',
-            'default' => 'takeout'
+            'default' => 'takeout',
         ],
         [
             'shortname' => 'mgmt_port',
             'prompt' => 'Which management port would you like %s to use?',
-            'default' => 15672
+            'default' => 15672,
         ],
     ];
 

--- a/app/Services/RabbitMQ.php
+++ b/app/Services/RabbitMQ.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services;
+
+class RabbitMQ extends BaseService
+{
+    protected static $category = Category::CACHE;
+
+    protected $imageName = 'rabbitmq';
+    protected $defaultPort = 5672;
+    protected $prompts = [
+        [
+            'shortname' => 'hostname',
+            'prompt' => 'Which hostname would you like %s to use?',
+            'default' => 'takeout'
+        ],
+        [
+            'shortname' => 'mgmt_port',
+            'prompt' => 'Which management port would you like %s to use?',
+            'default' => 15672
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-h "${:hostname}" \
+        -p "${:port}":5672 \
+        -p "${:mgmt_port}":15672 \
+        "${:organization}"/"${:image_name}":"${:tag}"';
+}


### PR DESCRIPTION
Adds RabbitMQ as a service. This is an available feature on Laravel Homestead and one I use for my development, so I'd like to see it available in Takeout if possible!

Notes:

- RabbitMQ relies on the hostname to organize data, so it's important we specify the hostname (-h option, comes from [RabbitMQ docker docs](https://hub.docker.com/_/rabbitmq))
- The default `latest` tag does not enable the management plugin, so opening/asking about the management port is unnecessary. I didn't know any way to conditionally ask for a management port based on the tag selected, so I overrode the default prompts so that `management` is the suggested default tag. Not sure if that's bad form 😂

Thanks for considering this! Love Takeout and how easy it makes using Docker in my dev workflow!