### PR TITLE
Add matrix entry for Apple Silicon

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,10 @@ jobs:
                   - os: macOS
                     os-version: macos-latest
 
+                  - os: macOS-11
+                    os-version: macos-11.0
+                    php: 8.0
+
         name: ${{ matrix.os }} - PHP ${{ matrix.php }}
 
         runs-on: ${{ matrix.os-version }}


### PR DESCRIPTION
Closes #205 

This PR adds a matrix entry to also test `takeout` on Apple Silicon, this way all platforms that `takout` is probably going to be run on are covered. 