### PR TITLE
Fixes PSR-4 issues

### DIFF
--- a/tests/Feature/MicrosoftDockerTagsTest.php
+++ b/tests/Feature/MicrosoftDockerTagsTest.php
@@ -7,6 +7,7 @@ use App\Shell\MicrosoftDockerTags;
 use GuzzleHttp\Client;
 use Mockery as M;
 use Tests\TestCase;
+use Tests\Support\MicrosoftDockerTagsFakestream;
 
 class MicrosoftDockerTagsTest extends TestCase
 {

--- a/tests/support/MicrosoftDockerTagsFakestream.php
+++ b/tests/support/MicrosoftDockerTagsFakestream.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Support;
 
 use GuzzleHttp\Psr7\Stream as Psr7Stream;
 


### PR DESCRIPTION
Fixes the below error during `composer install`

```
Class Tests\Feature\MicrosoftDockerTagsFakestream located in ./tests/support/MicrosoftDockerTagsFakestream.php does not comply with psr-4 autoloading standard. Skipping.
```