### PR TITLE
add MailDev service

### DIFF
--- a/app/Services/MailDev.php
+++ b/app/Services/MailDev.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services;
+
+class MailDev extends BaseService
+{
+    protected static $category = Category::MAIL;
+
+    protected $organization = 'maildev';
+    protected $imageName = 'maildev';
+    protected $defaultPort = 1025;
+    protected $defaultPrompts = [
+        [
+            'shortname' => 'port',
+            'prompt' => 'Which host port would you like %s to use?',
+            // Default is set in the constructor
+        ],
+        [
+            'shortname' => 'tag',
+            'prompt' => 'Which tag (version) of %s would you like to use?',
+            'default' => '1.1.0',
+        ],
+    ];
+    protected $prompts = [
+        [
+            'shortname' => 'web_port',
+            'prompt' => 'What will the web port be?',
+            'default' => '8025',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "${:port}":25 \
+        -p "${:web_port}":80 \
+        "${:organization}"/"${:image_name}":"${:tag}"';
+}


### PR DESCRIPTION
this PR adds the MailDev service as an alternative to MailHog.

why is MailDev MegaCool™?

1. when you get a new email you're getting updated directly in the tab title

![Screen Recording 2021-02-01 at 00 25 38](https://user-images.githubusercontent.com/121373/106390647-59048200-6424-11eb-809f-1627aed2456d.gif)

2. MailDev has some PrettyCool™ features like responsive view, see email as text, etc

![Screen Recording 2021-02-01 at 00 29 14](https://user-images.githubusercontent.com/121373/106390735-c7e1db00-6424-11eb-9843-f2a57e794153.gif)

might be worth adding some competition to MailHog. who knows.
