### PR TITLE
Fix start and stop command bug where default menu closes early

### DIFF
--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -33,6 +33,7 @@ class StartCommand extends Command
             foreach ($containers as $container) {
                 $this->start($container);
             }
+
             return;
         }
 
@@ -40,11 +41,13 @@ class StartCommand extends Command
             foreach ($this->docker->startableTakeoutContainers() as $startableContainer) {
                 $this->start($startableContainer['container_id']);
             }
+
             return;
         }
 
         if (! $startableContainers = $this->startableContainers()) {
             $this->info("No Takeout containers available to start.\n");
+
             return;
         }
 
@@ -147,11 +150,12 @@ class StartCommand extends Command
                 }
             }
 
-            if (! Arr::has($menu->getItems(), ['use.label'])) {
+            if (count($menu->getItems()) === 3) {
                 $menu->close();
 
                 return;
             }
+
             $menu->redraw();
         };
     }

--- a/app/Commands/StopCommand.php
+++ b/app/Commands/StopCommand.php
@@ -33,6 +33,7 @@ class StopCommand extends Command
             foreach ($containers as $container) {
                 $this->stop($container);
             }
+
             return;
         }
 
@@ -40,6 +41,7 @@ class StopCommand extends Command
             foreach ($this->docker->stoppableTakeoutContainers() as $stoppableContainer) {
                 $this->stop($stoppableContainer['container_id']);
             }
+
             return;
         }
 
@@ -148,11 +150,12 @@ class StopCommand extends Command
                 }
             }
 
-            if (! Arr::has($menu->getItems(), ['use.label'])) {
+            if (count($menu->getItems()) === 3) {
                 $menu->close();
 
                 return;
             }
+
             $menu->redraw();
         };
     }


### PR DESCRIPTION
This should resolve issue #211.  Apparently my original implementation to close the start and stop command menu if only the exit item remained did not work for the default menu layout.  This has been reworked and now works as intended.