### PR TITLE
Adds port availability check for the MySQL service

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,27 @@ But you can also easily enable ElasticSearch, PostgreSQL, MSSQL, Mongo, Redis, a
 
 # Requirements
 
-- macOS, Linux, or WSL2
+- macOS, Linux, or WSL2 (also see [Linux Dependencies](#linux-dependencies))
 - Node installed or whatever
 - Docker installed (macOS: [Docker for Mac](https://docs.docker.com/docker-for-mac/))
+
+## Linux Dependencies
+<a name="linux-dependencies"></a>
+
+Some distros don't come with `netstat` installed by default, so you may need to install it yourself:
+
+```bash
+# Debian/Ubuntu
+apt-get install net-tools
+# CentOS/RHEL
+yum install net-tools
+# OpenSuse
+zypper install net-tools
+# Arch Linux
+pacman -S netstat-nat
+```
+
+You may need to run these as the `root` user.
 
 # Usage
 

--- a/src/services/mysql.ts
+++ b/src/services/mysql.ts
@@ -25,16 +25,15 @@ export default class MySQL extends BaseService {
       name: 'port',
       message: this.defaultPortMessage(),
       default: this.defaultPort,
-      validate: function (input: string|number) {
-        const portCheck = ((res: any, rej: any) => {
-          const a = EnvironmentShell.netstatCmd()
-          console.log('a: ', a)
-          if (parseInt(input, 10) === 3306) {
-            rej('Some error')
+      validate: function (port: number) {
+        return new Promise((res, rej) => {
+          if (! EnvironmentShell.isPortAvailable(port)) {
+            rej(`Port ${port} has already been taken. Try another one.`);
+            return;
           }
-          res(true)
+
+          res(true);
         })
-        return new Promise(portCheck)
       },
     },
     {

--- a/src/shell/environmentshell.ts
+++ b/src/shell/environmentshell.ts
@@ -7,11 +7,11 @@ export default class EnvironmentShell {
   }
 
   static netstatCmd(port: number): any {
-    // @TODO: is there any danger in concatenating the command like this? Do we need to escape it somehow?
     const portText = EnvironmentShell.isLinuxOs()
       ? `:${port} `
       : `.${port} `
 
+    // @TODO: is there any danger in concatenating the command like this? Do we need to escape it somehow?
     const cmd = `netstat -vanp tcp | grep '${portText}' | grep -v 'TIME_WAIT' | grep -v 'CLOSE_WAIT' | grep -v 'FIN_WAIT'`
 
     return spawn.sync('sh', ['-c', cmd])

--- a/src/shell/environmentshell.ts
+++ b/src/shell/environmentshell.ts
@@ -1,7 +1,23 @@
 const spawn = require('cross-spawn')
 
 export default class EnvironmentShell {
-  static netstatCmd(): string {
-    return spawn.sync("netstat -vanp tcp | grep '3306' | grep -v 'TIME_WAIT' | grep -v 'CLOSE_WAIT' | grep -v 'FIN_WAIT'")
+  static isPortAvailable(port: number): boolean {
+    const result = EnvironmentShell.netstatCmd(port)
+    return result.status !== 0
+  }
+
+  static netstatCmd(port: number): any {
+    // @TODO: is there any danger in concatenating the command like this? Do we need to escape it somehow?
+    const portText = EnvironmentShell.isLinuxOs()
+      ? `:${port} `
+      : `.${port} `
+
+    const cmd = `netstat -vanp tcp | grep '${portText}' | grep -v 'TIME_WAIT' | grep -v 'CLOSE_WAIT' | grep -v 'FIN_WAIT'`
+
+    return spawn.sync('sh', ['-c', cmd])
+  }
+
+  static isLinuxOs(): boolean {
+      return process.platform === 'linux'
   }
 }

--- a/src/shell/environmentshell.ts
+++ b/src/shell/environmentshell.ts
@@ -6,7 +6,7 @@ export default class EnvironmentShell {
     return result.status !== 0
   }
 
-  static netstatCmd(port: number): any {
+  static netstatCmd(port: number): { status: number } {
     const portText = EnvironmentShell.isLinuxOs()
       ? `:${port} `
       : `.${port} `


### PR DESCRIPTION
### Added

- Adds the port availability check for the MySQL service. I think this is something we could extract (to a validators folder?) so we could reuse in other services
- Adds a mention to install the `netstat` CLI tool if it's not already installed by default in the distro (mine wasn't)