### PR TITLE
Fix docker tags API response changed

### DIFF
--- a/app/Shell/DockerTags.php
+++ b/app/Shell/DockerTags.php
@@ -47,6 +47,7 @@ class DockerTags
         return collect($response['results'])
             ->pluck('name')
             ->sortDesc(SORT_NATURAL)
+            ->values()
             ->filter();
     }
 

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -48,8 +48,8 @@ class DockerTagsTest extends TestCase
         $dockerTags = app(DockerTags::class, ['service' => $postgres]);
         $tags = collect($dockerTags->getTags());
 
-        $this->assertEquals('latest', $tags->first());
-        $this->assertEquals('9', $tags->last());
+        $this->assertEquals('alpine', $tags->first());
+        $this->assertEquals('9-alpine', $tags->last());
         $this->assertCount(10, $tags);
     }
 }


### PR DESCRIPTION
### Fixed

- Fix the `DockerTagsTest` because the API response changed from the DockerHub API

---

Not sure if this is the most "correct" fix, though.