### PR TITLE
Allow enabling services with non-standard docker images

### DIFF
--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -158,10 +158,12 @@ abstract class BaseService
             $items[] = $prompt;
         }
 
+        // Allow users to pass custom docker images (e.g. "postgis/postgis:latest") when we ask for the tag
         if (Str::is('*:*', $this->promptResponses['tag'])) {
             [$image, $this->promptResponses['tag']] = explode(':', $this->promptResponses['tag']);
             [$this->promptResponses['organization'], $this->promptResponses['image_name']] = Str::is('*/*', $image) ? explode('/', $image) : [$this->organization, $image];
         }
+
         $this->tag = $this->resolveTag($this->promptResponses['tag']);
     }
 

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -158,6 +158,10 @@ abstract class BaseService
             $items[] = $prompt;
         }
 
+        if (Str::is('*:*', $this->promptResponses['tag'])) {
+            [$image, $this->promptResponses['tag']] = explode(':', $this->promptResponses['tag']);
+            [$this->promptResponses['organization'], $this->promptResponses['image_name']] = Str::is('*/*', $image) ? explode('/', $image) : [$this->organization, $image];
+        }
         $this->tag = $this->resolveTag($this->promptResponses['tag']);
     }
 


### PR DESCRIPTION
As described in #236 you sometimes want to use non-standard docker images because they have some plugins bundled you may want to use. Especially for PostgreSQL there are a lot of plugins not available in core, the most common is the PostGIS extension.

Instead of simply specifying a simple docker tag in the dialog you can now easily change the base by typing e.g. `postgis/postgis:latest`. This will also solve the [pull request for TimescaleDB](#227) as TimescaleDB is just a PostgreSQL extension.