### PR TITLE
Add a static port for the MinIO Console.

### DIFF
--- a/app/Services/Minio.php
+++ b/app/Services/Minio.php
@@ -16,6 +16,11 @@ class Minio extends BaseService
             'default' => 'minio_data',
         ],
         [
+            'shortname' => 'console',
+            'prompt' => 'Which host port would you like to be used by Minio Console?',
+            'default' => 9001,
+        ],
+        [
             'shortname' => 'access_key',
             'prompt' => 'What will the access key for Minio be?',
             'default' => 'minioadmin',
@@ -28,8 +33,9 @@ class Minio extends BaseService
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":9000 \
+        -p "${:console}":9001 \
         -e MINIO_ACCESS_KEY="${:access_key}" \
         -e MINIO_SECRET_KEY="${:secret_key}" \
         -v "${:volume}":/data \
-        "${:organization}"/"${:image_name}":"${:tag}" server /data';
+        "${:organization}"/"${:image_name}":"${:tag}" server /data --console-address ":9001"';
 }


### PR DESCRIPTION
Hello, by default, MinIO Console is listening on a dynamic port that is randomly generated in every run, which makes it impossible to log in.

> WARNING: Console endpoint is listening on a dynamic port (42055), please use --console-address ":PORT" to choose a static port.

https://docs.min.io/docs/minio-docker-quickstart-guide.html