### PR TITLE
Fix "latest" tag fallback

### DIFF
--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -12,24 +12,12 @@ use Tests\TestCase;
 class DockerTagsTest extends TestCase
 {
     /** @test */
-    function it_lists_10_newest_available_tags_for_service()
-    {
-        $mysql = app(MySql::class);
-        $dockerTags = app(DockerTags::class, ['service' => $mysql]);
-        $tags = $dockerTags->getTags();
-
-        $this->assertEquals('latest', $tags[0]);
-        $this->assertTrue($tags->contains('5.7'));
-        $this->assertCount(10, $tags);
-    }
-
-    /** @test */
     function it_gets_the_latest_tag_not_named_latest()
     {
         $dockerTags = M::mock(DockerTags::class, [app(Client::class), app(Mysql::class)])->makePartial();
-        $dockerTags->shouldReceive('getTags')->andReturn(collect(['latest', 'next latest tag']));
+        $dockerTags->shouldReceive('getTags')->andReturn(collect(['latest', 'some named tag', '1.0.0']));
 
-        $this->assertEquals('next latest tag', $dockerTags->getLatestTag());
+        $this->assertEquals('1.0.0', $dockerTags->getLatestTag());
     }
 
     /** @test */
@@ -49,7 +37,6 @@ class DockerTagsTest extends TestCase
         $tags = collect($dockerTags->getTags());
 
         $this->assertEquals('latest', $tags->first());
-        $this->assertEquals('9-buster', $tags->last());
-        $this->assertCount(10, $tags);
+        $this->assertEquals('9', $tags->last());
     }
 }


### PR DESCRIPTION
Docker Hub paginates the tag list page and in order to pull the full list of tags, we would need to authenticate, which I've been trying to avoid for complexity sake. Luckily, we can expand the `page_size` parameter and bump it up to read more tags without needing to authenticate.

The next step to my solution is to partition the named tags and the numerical tags. We can rely on the higher numerical tags to be the "actual latest" tags and we can ignore the named tags when takeout is searching for "actual latest".