### PR TITLE
Constrain GuzzleHTTP/PSR7 in GH Actions to avoid return type issues

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,6 +52,9 @@ jobs:
             - name: Install dependencies
               run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
 
+            - name: Constrain PSR-7 to avoid string conflict
+              run: composer require guzzlehttp/psr7:"^1.0"
+
             - name: Run tests
               run: vendor/bin/phpunit
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,7 +53,7 @@ jobs:
               run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-reqs
 
             - name: Constrain PSR-7 to avoid string conflict
-              run: composer require guzzlehttp/psr7:"^1.0" --ignore-platform-reqs
+              run: composer require guzzlehttp/psr7:"^1.7" --ignore-platform-reqs
 
             - name: Run tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,10 +50,10 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
+              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-reqs
 
             - name: Constrain PSR-7 to avoid string conflict
-              run: composer require guzzlehttp/psr7:"^1.0"
+              run: composer require guzzlehttp/psr7:"^1.0" --ignore-platform-reqs
 
             - name: Run tests
               run: vendor/bin/phpunit

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -14,7 +14,7 @@ class DockerTagsTest extends TestCase
     /** @test */
     function it_gets_the_latest_tag_not_named_latest()
     {
-        $dockerTags = M::mock(DockerTags::class, [app(Client::class), app(Mysql::class)])->makePartial();
+        $dockerTags = M::mock(DockerTags::class, [app(Client::class), app(MySql::class)])->makePartial();
         $dockerTags->shouldReceive('getTags')->andReturn(collect(['latest', 'some named tag', '1.0.0']));
 
         $this->assertEquals('1.0.0', $dockerTags->getLatestTag());
@@ -23,7 +23,7 @@ class DockerTagsTest extends TestCase
     /** @test */
     function if_latest_is_the_only_tag_it_returns_latest()
     {
-        $dockerTags = M::mock(DockerTags::class, [app(Client::class), app(Mysql::class)])->makePartial();
+        $dockerTags = M::mock(DockerTags::class, [app(Client::class), app(MySql::class)])->makePartial();
         $dockerTags->shouldReceive('getTags')->andReturn(collect(['latest']));
 
         $this->assertEquals('latest', $dockerTags->getLatestTag());


### PR DESCRIPTION
These issues will only show up in tests, so they don't need to be real constrains in `composer.json`