### PR TITLE
Add OpenSearch service

### DIFF
--- a/app/Services/OpenSearch.php
+++ b/app/Services/OpenSearch.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services;
+
+class OpenSearch extends BaseService
+{
+    protected static $category = Category::SEARCH;
+
+    protected $organization = 'opensearchproject';
+    protected $imageName = 'opensearchproject/opensearch';
+    protected $defaultPort = 9200;
+    protected $prompts = [
+        [
+            'shortname' => 'volume',
+            'prompt' => 'What is the Docker volume name?',
+            'default' => 'opensearch_data',
+        ],
+        [
+            'shortname' => 'analyzer_port',
+            'prompt' => 'Which host port would you like to be used by the performance analyzer?',
+            'default' => 9600,
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "${:port}":9200 \
+        -p ${:analyzer_port}:9600
+        -e "discovery.type=single-node"  \
+        -v "${:volume}":/usr/share/opensearch/data \
+         "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected static $displayName = 'OpenSearch';
+}

--- a/app/Services/OpenSearch.php
+++ b/app/Services/OpenSearch.php
@@ -7,7 +7,7 @@ class OpenSearch extends BaseService
     protected static $category = Category::SEARCH;
 
     protected $organization = 'opensearchproject';
-    protected $imageName = 'opensearchproject/opensearch';
+    protected $imageName = 'opensearch';
     protected $defaultPort = 9200;
     protected $prompts = [
         [
@@ -23,10 +23,10 @@ class OpenSearch extends BaseService
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":9200 \
-        -p ${:analyzer_port}:9600
+        -p "${:analyzer_port}":9600 \
         -e "discovery.type=single-node"  \
         -v "${:volume}":/usr/share/opensearch/data \
-         "${:organization}"/"${:image_name}":"${:tag}"';
+        "${:organization}"/"${:image_name}":"${:tag}"';
 
     protected static $displayName = 'OpenSearch';
 }


### PR DESCRIPTION
Adds OpenSearch as a service.

AWS no longer has a relationship with ElasticSearch and have moved to the OpenSearch standard, forking from version 7.10.2 of ElasticSearch. This allows development directly against OS