### PR TITLE
Use mysql/mysql-server image for ARM processors

### DIFF
--- a/app/Services/MySql.php
+++ b/app/Services/MySql.php
@@ -6,7 +6,8 @@ class MySql extends BaseService
 {
     protected static $category = Category::DATABASE;
 
-    protected $imageName = 'mysql';
+    protected $organization = 'mysql';
+    protected $imageName = 'mysql-server';
     protected $defaultPort = 3306;
     protected $prompts = [
         [
@@ -33,7 +34,7 @@ class MySql extends BaseService
     {
         $parameters = parent::buildParameters();
 
-        $parameters['allow_empty_password'] = $parameters['root_password'] === '' ? 'yes' : 'no';
+        $parameters['allow_empty_password'] = $parameters['root_password'] === '' ? '1' : '0';
 
         return $parameters;
     }


### PR DESCRIPTION
### Changed

- Changes the MySQL service to use the `mysql/mysql-server` image by default instead of the `mysql` one, as the former seems to work well on ARM-based processors (M1)

---

This is based on a recent change made to [Laravel Sail](https://github.com/laravel/sail/pull/272)