### PR TITLE
MySQL on M1

### DIFF
--- a/app/Services/MySql.php
+++ b/app/Services/MySql.php
@@ -25,6 +25,7 @@ class MySql extends BaseService
     protected $dockerRunTemplate = '-p "${:port}":3306 \
         -e MYSQL_ROOT_PASSWORD="${:root_password}" \
         -e MYSQL_ALLOW_EMPTY_PASSWORD="${:allow_empty_password}" \
+        -e MYSQL_ROOT_HOST="%" \
         -v "${:volume}":/var/lib/mysql \
         "${:organization}"/"${:image_name}":"${:tag}" --default-authentication-plugin=mysql_native_password';
 

--- a/app/Services/MySql.php
+++ b/app/Services/MySql.php
@@ -6,7 +6,8 @@ class MySql extends BaseService
 {
     protected static $category = Category::DATABASE;
 
-    protected $imageName = 'mysql';
+    protected $organization = 'mysql';
+    protected $imageName = 'mysql-server';
     protected $defaultPort = 3306;
     protected $prompts = [
         [
@@ -33,7 +34,7 @@ class MySql extends BaseService
     {
         $parameters = parent::buildParameters();
 
-        $parameters['allow_empty_password'] = $parameters['root_password'] === '' ? 'yes' : 'no';
+        $parameters['allow_empty_password'] = $parameters['root_password'] === '' ? '1' : '0';
 
         return $parameters;
     }

--- a/app/Shell/DockerTags.php
+++ b/app/Shell/DockerTags.php
@@ -71,12 +71,12 @@ class DockerTags
      */
     protected function armSupportedImagesOnlyFilter()
     {
-        return function ($results) {
+        return function ($tags) {
             $platform = $this->platform();
 
             // We need to take into account if the M1 chip is supported by the tag.
-            return $results->filter(function ($results) use ($platform) {
-                return collect($results['images'])
+            return $tags->filter(function ($tag) use ($platform) {
+                return collect($tag['images'])
                     ->pluck('architecture')
                     ->contains($platform);
             });
@@ -90,9 +90,9 @@ class DockerTags
      */
     protected function nonArmOnlySupportImagesFilter()
     {
-        return function ($results) {
-            return $results->filter(function ($results) {
-                $supportedArchitectures = collect($results['images'])
+        return function ($tags) {
+            return $tags->filter(function ($tag) {
+                $supportedArchitectures = collect($tag['images'])
                     ->pluck('architecture')
                     ->unique()
                     ->values();

--- a/app/Shell/DockerTags.php
+++ b/app/Shell/DockerTags.php
@@ -74,7 +74,8 @@ class DockerTags
         return function ($tags) {
             $platform = $this->platform();
 
-            // We need to take into account if the M1 chip is supported by the tag.
+            // We only want tags that specify arm64 in the supported architecture.
+
             return $tags->filter(function ($tag) use ($platform) {
                 return collect($tag['images'])
                     ->pluck('architecture')
@@ -97,7 +98,9 @@ class DockerTags
                     ->unique()
                     ->values();
 
-                // They should have more architecture options when removing 'arm64'.
+                // When removing the arm64 option from the list, there should
+                // still be other options in the supported architectures
+                // so we can consider that the tag is not arm-only.
 
                 return $supportedArchitectures->diff(['arm64'])->count() > 0;
             });

--- a/app/Shell/DockerTags.php
+++ b/app/Shell/DockerTags.php
@@ -72,14 +72,10 @@ class DockerTags
     protected function armSupportedImagesOnlyFilter()
     {
         return function ($tags) {
-            $platform = $this->platform();
-
-            // We only want tags that specify arm64 in the supported architecture.
-
             return $tags->filter(function ($tag) use ($platform) {
                 return collect($tag['images'])
                     ->pluck('architecture')
-                    ->contains($platform);
+                    ->contains('arm64');
             });
         };
     }

--- a/app/Shell/DockerTags.php
+++ b/app/Shell/DockerTags.php
@@ -65,7 +65,7 @@ class DockerTags
     }
 
     /**
-     * Filter that ensures images that do not support arm architecture are filtered out.
+     * Return a function intended to filter tags, ensuring images that do not support arm architecture are filtered out.
      *
      * @return callable
      */
@@ -85,7 +85,7 @@ class DockerTags
     }
 
     /**
-     * Filter that ensures are arm-only images are filtered out.
+     * Return a function intended to filter tags, that ensures are arm-only images are filtered out.
      *
      * @return callable
      */

--- a/app/Shell/DockerTags.php
+++ b/app/Shell/DockerTags.php
@@ -64,6 +64,11 @@ class DockerTags
         return $sortedTags->values()->filter();
     }
 
+    /**
+     * Filter that ensures images that do not support arm architecture are filtered out.
+     *
+     * @return callable
+     */
     protected function armSupportedImagesOnlyFilter()
     {
         return function ($results) {
@@ -78,6 +83,11 @@ class DockerTags
         };
     }
 
+    /**
+     * Filter that ensures are arm-only images are filtered out.
+     *
+     * @return callable
+     */
     protected function nonArmOnlySupportImagesFilter()
     {
         return function ($results) {

--- a/app/Shell/DockerTags.php
+++ b/app/Shell/DockerTags.php
@@ -72,7 +72,7 @@ class DockerTags
     protected function armSupportedImagesOnlyFilter()
     {
         return function ($tags) {
-            return $tags->filter(function ($tag) use ($platform) {
+            return $tags->filter(function ($tag) {
                 return collect($tag['images'])
                     ->pluck('architecture')
                     ->contains('arm64');

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -10,6 +10,8 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Mockery as M;
+use Tests\Support\IntelDockerTags;
+use Tests\Support\M1DockerTags;
 use Tests\TestCase;
 
 class DockerTagsTest extends TestCase
@@ -94,21 +96,5 @@ class DockerTagsTest extends TestCase
                 ],
             ])),
         ]);
-    }
-}
-
-class M1DockerTags extends DockerTags
-{
-    protected function platform(): string
-    {
-        return 'arm64';
-    }
-}
-
-class IntelDockerTags extends DockerTags
-{
-    protected function platform(): string
-    {
-        return 'x86_64';
     }
 }

--- a/tests/Support/IntelDockerTags.php
+++ b/tests/Support/IntelDockerTags.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Shell\DockerTags;
+
+class IntelDockerTags extends DockerTags
+{
+    protected function platform(): string
+    {
+        return 'x86_64';
+    }
+}

--- a/tests/Support/M1DockerTags.php
+++ b/tests/Support/M1DockerTags.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Shell\DockerTags;
+
+class M1DockerTags extends DockerTags
+{
+    protected function platform(): string
+    {
+        return 'arm64';
+    }
+}


### PR DESCRIPTION
### Changed

- Changes the MySQL service to use `mysql/mysql-server`

### Fixed

- Fixes the `latest` tag resolution to take into account M1 chips (`arm64` architecture) when deciding which tag to use
- Fixes not being able to connect to the container from host with root due to missing `MYSQL_ROOT_HOST` env var (https://github.com/tighten/takeout/issues/190)

---

<details>

<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/1178621/141499057-cf339706-8475-4644-b7f6-6afa2e661af4.png)

</details>