### PR TITLE
Add `phpunit.xml` to the `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.vagrant
 .phpunit.result.cache
 /storage
+phpunit.xml


### PR DESCRIPTION
I see the project already makes use of the `phpunit.xml.dist` file instead of the normal `phpunit.xml` file. This makes it possible to make local-only changes to your testsuite.

To fully support this, it is common to ignore the phpunit.xml file in projects.

The PR's will not get smaller than this one ;p