### PR TITLE
Set Minio domain to allow dns buckets

### DIFF
--- a/app/Services/Minio.php
+++ b/app/Services/Minio.php
@@ -24,6 +24,11 @@ class Minio extends BaseService
             'default' => 9001,
         ],
         [
+            'shortname' => 'domain',
+            'prompt' => 'What domain will Minio be accessible at (optional, to allow dns buckets)?',
+            'default' => 'localhost',
+        ],
+        [
             'shortname' => 'root_user',
             'prompt' => 'What will the root user name for Minio be?',
             'default' => 'minioadmin',
@@ -39,6 +44,7 @@ class Minio extends BaseService
         -p "${:console}":9001 \
         -e MINIO_ROOT_USER="${:root_user}" \
         -e MINIO_ROOT_PASSWORD="${:root_password}" \
+        -e MINIO_DOMAIN="${:domain}" \
         -v "${:volume}":/data \
         "${:organization}"/"${:image_name}":"${:tag}" server /data --console-address ":9001"';
 }

--- a/app/Services/Minio.php
+++ b/app/Services/Minio.php
@@ -26,7 +26,7 @@ class Minio extends BaseService
         [
             'shortname' => 'domain',
             'prompt' => 'What domain will Minio be accessible at (optional, to allow dns buckets)?',
-            'default' => 'localhost',
+            'default' => '',
         ],
         [
             'shortname' => 'root_user',
@@ -44,7 +44,15 @@ class Minio extends BaseService
         -p "${:console}":9001 \
         -e MINIO_ROOT_USER="${:root_user}" \
         -e MINIO_ROOT_PASSWORD="${:root_password}" \
-        -e MINIO_DOMAIN="${:domain}" \
         -v "${:volume}":/data \
         "${:organization}"/"${:image_name}":"${:tag}" server /data --console-address ":9001"';
+
+    protected function prompts(): void
+    {
+        parent::prompts();
+
+        if ('' !== $this->promptResponses['domain']) {
+            $this->dockerRunTemplate = '-e MINIO_DOMAIN="${:domain}" '.$this->dockerRunTemplate;
+        }
+    }
 }

--- a/app/Services/Minio.php
+++ b/app/Services/Minio.php
@@ -52,7 +52,7 @@ class Minio extends BaseService
         parent::prompts();
 
         if ('' !== $this->promptResponses['domain']) {
-            $this->dockerRunTemplate = '-e MINIO_DOMAIN="${:domain}" '.$this->dockerRunTemplate;
+            $this->dockerRunTemplate = '-e MINIO_DOMAIN="${:domain}" ' . $this->dockerRunTemplate;
         }
     }
 }


### PR DESCRIPTION
Closes #264.

However, it would probably be preferable for the domain default to be null and then to not include `MINIO_DOMAIN` in the run template at all, it wasn't immediately clear to me how that would best be accomplished, so I instead opted for a sensible default of localhost.