### PR TITLE
Upgrade Laravel Zero to v9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 os: [Ubuntu, Windows, macOS]
-                php: [7.3, 7.4, 8.0, 8.1]
+                php: [8.0, 8.1]
                 # php: [7.2, 7.3, 7.4, 8.0]
 
                 include:

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "guzzlehttp/psr7": "^1.7"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^7.0",
-        "laravel-zero/framework": "^8.0",
+        "guzzlehttp/guzzle": "^7.4",
+        "laravel-zero/framework": "^9.0",
         "mockery/mockery": "^1.3.1",
-        "nunomaduro/laravel-console-menu": "^3.0",
+        "nunomaduro/laravel-console-menu": "^3.3",
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.5",
-        "tightenco/tlint": "^5.0"
+        "tightenco/tlint": "^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Upgrades the Laravel Zero package to v9, which drops PHP7 support. I bumped the associated dependencies to ensure we got the correct minimum versions and also bumped the tlint package to v6 to satisfy the requirements.

I was successfully able to build and run Takeout using PHP 8.1.3 after performing this upgrade.