### PR TITLE
Prompt to stop Docker in Mac, Windows, and Linux after disabling last container

### DIFF
--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -131,7 +131,7 @@ class DisableCommand extends Command
                 $this->info("\n docker volume rm {$volumeName}");
             }
 
-            if (count($this->docker->allContainers()) === 0 && ($this->environment->isLinuxOs() || $this->environment->isWindowsOs())) {
+            if (count($this->docker->allContainers()) === 0) {
                 $question = 'No containers are running. Turn off Docker?';
 
                 if ($this->environment->isWindowsOs()) {

--- a/app/Shell/Docker.php
+++ b/app/Shell/Docker.php
@@ -184,12 +184,12 @@ class Docker
     public function stopDockerService(): void
     {
         if ($this->environment->isWindowsOs()) {
-            $this->shell->execQuietly("wsl -t docker-desktop");
-            $this->shell->execQuietly("wsl -t docker-desktop-data");
+            $this->shell->execQuietly('wsl -t docker-desktop');
+            $this->shell->execQuietly('wsl -t docker-desktop-data');
         } elseif ($this->environment->isMacOs()) {
             $this->shell->execQuietly("test -z $(docker ps -q 2>/dev/null) && osascript -e 'quit app \"Docker\"'");
         } elseif ($this->environment->isLinuxOs()) {
-            $this->shell->execQuietly("systemctl stop docker");
+            $this->shell->execQuietly('systemctl stop docker');
         } else {
             // BSD, Solaris, Unknown
             throw new Exception('Cannot stop Docker in PHP_OS_FAMILY ' . PHP_OS_FAMILY);

--- a/app/Shell/Docker.php
+++ b/app/Shell/Docker.php
@@ -3,6 +3,7 @@
 namespace App\Shell;
 
 use App\Exceptions\DockerContainerMissingException;
+use App\Shell\Environment;
 use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -12,12 +13,14 @@ class Docker
     protected $shell;
     protected $formatter;
     protected $networking;
+    protected $environment;
 
-    public function __construct(Shell $shell, DockerFormatter $formatter, DockerNetworking $networking)
+    public function __construct(Shell $shell, DockerFormatter $formatter, DockerNetworking $networking, Environment $environment)
     {
         $this->shell = $shell;
         $this->formatter = $formatter;
         $this->networking = $networking;
+        $this->environment = $environment;
     }
 
     public function removeContainer(string $containerId): void
@@ -180,7 +183,17 @@ class Docker
 
     public function stopDockerService(): void
     {
-        $this->shell->execQuietly("test -z $(docker ps -q 2>/dev/null) && osascript -e 'quit app \"Docker\"'");
+        if ($this->environment->isWindowsOs()) {
+            $this->shell->execQuietly("wsl -t docker-desktop");
+            $this->shell->execQuietly("wsl -t docker-desktop-data");
+        } elseif ($this->environment->isMacOs()) {
+            $this->shell->execQuietly("test -z $(docker ps -q 2>/dev/null) && osascript -e 'quit app \"Docker\"'");
+        } elseif ($this->environment->isLinuxOs()) {
+            $this->shell->execQuietly("systemctl stop docker");
+        } else {
+            // BSD, Solaris, Unknown
+            throw new Exception('Cannot stop Docker in PHP_OS_FAMILY ' . PHP_OS_FAMILY);
+        }
     }
 
     protected function runAndParseTable(string $command): Collection

--- a/app/Shell/Environment.php
+++ b/app/Shell/Environment.php
@@ -13,6 +13,11 @@ class Environment
         $this->shell = $shell;
     }
 
+    public function isMacOs(): bool
+    {
+        return PHP_OS_FAMILY === 'Darwin';
+    }
+
     public function isLinuxOs(): bool
     {
         return PHP_OS_FAMILY === 'Linux';


### PR DESCRIPTION
Replaces #150 
Closes #112 

Re-worked #150 given some changes we've made to the `DisableContainer` command