### PR TITLE
Improve Start and Stop DX

### DIFF
--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -75,7 +75,7 @@ class DisableCommand extends Command
                 $serviceContainerId = $serviceMatches->flip()->first();
                 break;
             default: // > 1
-                $serviceContainerId = $this->selectMenu($disableableServices ?? $this->disableableServices);
+                $serviceContainerId = $this->selectMenu($this->disableableServices);
 
                 if (! $serviceContainerId) {
                     return;

--- a/app/Commands/StartCommand.php
+++ b/app/Commands/StartCommand.php
@@ -6,7 +6,6 @@ use App\InitializesCommands;
 use App\Shell\Docker;
 use App\Shell\Environment;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
 use PhpSchool\CliMenu\CliMenu;

--- a/app/Commands/StopCommand.php
+++ b/app/Commands/StopCommand.php
@@ -85,7 +85,23 @@ class StopCommand extends Command
             return;
         }
 
-        $this->stop($containersByServiceName->first()['container']['container_id']);
+        if ($containersByServiceName->count() === 1) {
+            $this->stop($containersByServiceName->first()['container']['container_id']);
+            return;
+        }
+
+        $selectedContainer = $this->loadMenu($containersByServiceName->map(function ($item) {
+            $label = $item['container']['container_id'] . ' - ' . $item['label'];
+
+            return [
+                $label,
+                $this->loadMenuItem($item['container'], $label),
+            ];
+        })->all());
+
+        if (! $selectedContainer) return;
+
+        $this->stop($selectedContainer);
     }
 
     public function stop(string $container): void
@@ -97,20 +113,18 @@ class StopCommand extends Command
         $this->docker->stopContainer($container);
     }
 
-    private function loadMenu($stoppableContainers): void
+    private function loadMenu($stoppableContainers)
     {
         if ($this->environment->isWindowsOs()) {
-            $this->windowsMenu($stoppableContainers);
-
-            return;
+            return $this->windowsMenu($stoppableContainers);
         }
 
-        $this->defaultMenu($stoppableContainers);
+        return $this->defaultMenu($stoppableContainers);
     }
 
     private function defaultMenu($stoppableContainers)
     {
-        $this->menu(self::MENU_TITLE)
+        return $this->menu(self::MENU_TITLE)
             ->addItems($stoppableContainers)
             ->addLineBreak('', 1)
             ->open();
@@ -138,7 +152,7 @@ class StopCommand extends Command
             return $value[0] === $choice;
         });
 
-        call_user_func(array_values($chosenStoppableContainer)[0][1]);
+        return call_user_func(array_values($chosenStoppableContainer)[0][1]);
     }
 
     private function loadMenuItem($container, $label): callable

--- a/app/Commands/StopCommand.php
+++ b/app/Commands/StopCommand.php
@@ -99,7 +99,9 @@ class StopCommand extends Command
             ];
         })->all());
 
-        if (! $selectedContainer) return;
+        if (! $selectedContainer) {
+            return;
+        }
 
         $this->stop($selectedContainer);
     }

--- a/tests/Feature/StartCommandTest.php
+++ b/tests/Feature/StartCommandTest.php
@@ -96,4 +96,64 @@ class StartCommandTest extends TestCase
         $this->artisan('start', ['containerId' => ['mysql']])
             ->assertExitCode(0);
     }
+
+    /** @test */
+    function it_can_start_containers_by_name_when_there_are_multiple()
+    {
+        $services = Collection::make([
+            [
+                'container_id' => $firstContainerId = '12345',
+                'names' => $firstContainerName = 'TO--mysql--8.0.22--3306',
+                'status' => 'Exited (0) 8 days ago',
+                'ports' => '',
+                'base_alias' => 'mysql',
+                'full_alias' => 'mysql8.0',
+            ],
+            [
+                'container_id' => $secondContainerId = '67890',
+                'names' => $secondContainerName = 'TO--mysql--8.0.20-3306',
+                'status' => 'Exited (0) 8 days ago',
+                'ports' => '',
+                'base_alias' => 'mysql',
+                'full_alias' => 'mysql8.0',
+            ],
+        ]);
+
+        $this->mock(Docker::class, function ($mock) use ($services, $secondContainerId) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+            $mock->shouldReceive('startableTakeoutContainers')->andReturn($services, new Collection);
+            $mock->shouldReceive('startContainer')->with($secondContainerId)->once();
+        });
+
+        $menuItems = [
+            $firstContainerId . ' - ' . $firstContainerName,
+            $mysql = $secondContainerId . ' - ' . str_replace('TO--', '', $secondContainerName),
+            '<info>Exit</>',
+        ];
+
+        if ($this->isWindows()) {
+            $this->artisan('start')
+                ->expectsChoice('Takeout containers to start', $mysql, $menuItems)
+                ->assertExitCode(0);
+        } else {
+            $menuMock = $this->mock(Menu::class, function ($mock) use ($mysql) {
+                $mock->shouldReceive('setTitleSeparator')->andReturnSelf();
+                $mock->shouldReceive('addItems')->andReturnSelf();
+                $mock->shouldReceive('addLineBreak')->andReturnSelf();
+                $mock->shouldReceive('open')->andReturn($mysql)->once();
+            });
+
+            Command::macro(
+                'menu',
+                function (string $title) use ($menuMock) {
+                    Assert::assertEquals('Takeout containers to start', $title);
+
+                    return $menuMock;
+                }
+            );
+
+            $this->artisan('start', ['containerId' => ['mysql']]);
+        }
+    }
 }

--- a/tests/Feature/StartCommandTest.php
+++ b/tests/Feature/StartCommandTest.php
@@ -71,4 +71,29 @@ class StartCommandTest extends TestCase
             $this->artisan('start');
         }
     }
+
+    /** @test */
+    function it_can_start_containers_by_name()
+    {
+        $services = Collection::make([
+            [
+                'container_id' => $containerId = '12345',
+                'names' => 'TO--mysql--8.0.22--3306',
+                'status' => 'Exited (0) 8 days ago',
+                'ports' => '',
+                'base_alias' => 'mysql',
+                'full_alias' => 'mysql8.0',
+            ],
+        ]);
+
+        $this->mock(Docker::class, function ($mock) use ($services, $containerId) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+            $mock->shouldReceive('startableTakeoutContainers')->andReturn($services, new Collection);
+            $mock->shouldReceive('startContainer')->once()->with($containerId);
+        });
+
+        $this->artisan('start', ['containerId' => ['mysql']])
+            ->assertExitCode(0);
+    }
 }

--- a/tests/Feature/StartCommandTest.php
+++ b/tests/Feature/StartCommandTest.php
@@ -128,7 +128,7 @@ class StartCommandTest extends TestCase
 
         $menuItems = [
             $firstContainerId . ' - ' . $firstContainerName,
-            $mysql = $secondContainerId . ' - ' . str_replace('TO--', '', $secondContainerName),
+            $mysql = $secondContainerId . ' - ' . $secondContainerName,
             '<info>Exit</>',
         ];
 


### PR DESCRIPTION
### Changed

- Adds the ability to start and stop containers by service name. Currently, to start/stop specific containers we need to pass the container ID. With this change, we get the ability to also pass the service name of such containers. This makes the start/stop commands behave closer to enable/disable.

---

Before:

```bash
takeout start 123123123
```

Now:
```bash
takeout start mysql
```

resolves #284