### PR TITLE
Add prompts for security on OpenSearch and ElasticSearch services

### DIFF
--- a/app/Services/ElasticSearch.php
+++ b/app/Services/ElasticSearch.php
@@ -18,10 +18,16 @@ class ElasticSearch extends BaseService
             'prompt' => 'What is the Docker volume name?',
             'default' => 'elastic_data',
         ],
+        [
+            'shortname' => 'enable_security',
+            'prompt' => 'Enable security (true or false)?',
+            'default' => 'true',
+        ],
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":9200 \
-        -e "discovery.type=single-node"  \
+        -e "discovery.type=single-node" \
+        -e xpack.security.enabled="${:enable_security}" \
         -v "${:volume}":/usr/share/elasticsearch/data \
          "${:organization}"/"${:image_name}":"${:tag}"';
 

--- a/app/Services/OpenSearch.php
+++ b/app/Services/OpenSearch.php
@@ -20,10 +20,16 @@ class OpenSearch extends BaseService
             'prompt' => 'Which host port would you like to be used by the performance analyzer?',
             'default' => 9600,
         ],
+        [
+            'shortname' => 'disable_security',
+            'prompt' => 'Disable security plugin (true or false)?',
+            'default' => 'false',
+        ],
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":9200 \
         -p "${:analyzer_port}":9600 \
+        -e DISABLE_SECURITY_PLUGIN="${:disable_security}"  \
         -e "discovery.type=single-node"  \
         -v "${:volume}":/usr/share/opensearch/data \
         "${:organization}"/"${:image_name}":"${:tag}"';


### PR DESCRIPTION
Using the search services without security is not simply a case of changing client config, the services need to be configured as well.

This makes using Opensearch and Elasticsearch without security or SSL possible. The defaults are set to secure.

Note that the opensearch change enables HTTP access, which is less troublesome than HTTPS.

The Elasticsearch change enables access without having to provide username and password like:
```
curl http://elastic:changeme@127.0.0.1:9200
```

HTTPS access on Elasticsearch is only available to paid subscriptions and requires a license key, which I dont think this tool would use.