### PR TITLE
Add builds folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/builds
 /vendor
 /.idea
 /.vscode


### PR DESCRIPTION
I notice the builds folder with the takeout binary is not ignored, someone will commit that at some point by mistake. This ignores the folder.