### PR TITLE
Fix GitHub Actions tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,7 +54,7 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-reqs
+              run: composer update --prefer-stable --prefer-dist --no-interaction
 
             - name: Run tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,7 +54,7 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: composer update --prefer-stable --prefer-dist --no-interaction
+              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-req=ext-fileinfo
 
             - name: Run tests
               run: vendor/bin/phpunit


### PR DESCRIPTION
First, dropping `--ignore-platform-reqs` to fix tests for PHP 8, and then seeing if we need to make other changes to re-fix the problem it was introduced to solve: https://github.com/tighten/takeout/pull/136

Dropping `--ignore-platform-reqs` fixed Ubuntu PHP 8.0, but broke Windows again because of a missing `ext-fileinfo` extension, so next I made *only* that extension ignored, which seems have to fixed the problem.