### PR TITLE
Changed the MSSQL image for one that works on M1

### DIFF
--- a/app/Services/MsSql.php
+++ b/app/Services/MsSql.php
@@ -9,7 +9,7 @@ class MsSql extends BaseService
     protected static $category = Category::DATABASE;
 
     protected $organization = 'mcr.microsoft.com';
-    protected $imageName = 'mssql/server';
+    protected $imageName = 'azure-sql-edge';
     protected $dockerTagsClass = MicrosoftDockerTags::class;
     protected $defaultPort = 1433;
     protected $prompts = [

--- a/app/Shell/MicrosoftDockerTags.php
+++ b/app/Shell/MicrosoftDockerTags.php
@@ -3,7 +3,6 @@
 namespace App\Shell;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 class MicrosoftDockerTags extends DockerTags
 {
@@ -16,9 +15,7 @@ class MicrosoftDockerTags extends DockerTags
     {
         return collect(json_decode($this->getTagsResponse(), true)['tags'])
             ->reverse()
-            ->filter(function ($tag) {
-                return Str::contains($tag, '-GA-');
-            });
+            ->values();
     }
 
     protected function tagsUrlTemplate(): string

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -42,7 +42,7 @@ class DockerTagsTest extends TestCase
         $tags = collect($dockerTags->getTags());
 
         $this->assertEquals('latest', $tags->first());
-        $this->assertEquals('9-bullseye', $tags->last());
+        $this->assertEquals('10', $tags->last());
     }
 
     /** @test */

--- a/tests/Feature/MicrosoftDockerTagsTest.php
+++ b/tests/Feature/MicrosoftDockerTagsTest.php
@@ -12,29 +12,6 @@ use Tests\TestCase;
 class MicrosoftDockerTagsTest extends TestCase
 {
     /** @test */
-    function it_gets_a_general_availability_release()
-    {
-        $dockerTags = app(MicrosoftDockerTags::class, ['service' => app(MsSql::class)]);
-        $this->assertStringContainsString('-GA-', $dockerTags->getLatestTag());
-    }
-
-    /** @test */
-    function it_ignores_tags_without_ga_string()
-    {
-        $mssql = app(MsSql::class);
-        $dockerTags = M::mock(MicrosoftDockerTags::class, [app(Client::class), $mssql])
-            ->makePartial()
-            ->shouldAllowMockingProtectedMethods();
-
-        $dockerTags->shouldReceive('getTagsResponse')->andReturn(new MicrosoftDockerTagsFakestream('abc'));
-
-        $tags = $dockerTags->getTags();
-
-        $this->assertEquals(2, $tags->count());
-        $this->assertStringContainsString('-GA-', $tags->first());
-    }
-
-    /** @test */
     function it_reverses_tag_list()
     {
         $mssql = app(MsSql::class);
@@ -44,6 +21,6 @@ class MicrosoftDockerTagsTest extends TestCase
 
         $dockerTags->shouldReceive('getTagsResponse')->andReturn(new MicrosoftDockerTagsFakestream('abc'));
 
-        $this->assertEquals('2024-GA-ubuntu-18.04', $dockerTags->getLatestTag());
+        $this->assertEquals('latest', $dockerTags->getLatestTag());
     }
 }


### PR DESCRIPTION
### Changed

- Changes the MSSQL image from `mssql/server` to `azure-sql-edge` which seems to be one that works on both M1 and Intel-based machines.

---

Note: We have only tested that when using the new image, the container (service) is able to run on M1 machines, we didn't fully tested if this image is a full replacement of the previous one. [The issue](https://github.com/tighten/takeout/issues/293) of where this change originated from mentions [this article](https://medium.com/geekculture/docker-express-running-a-local-sql-server-on-your-m1-mac-8bbc22c49dc9) which seems to imply it's a replacement.

resolves #293 