### PR TITLE
Adds a `--run` option to the enable command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You may specify extra arguments to the container after a `--` sepatator:
 takeout enable mysql -- -hsome.mysql.host -usome-user
 ```
 
-Notice that these are options for the container (arguments), not extra docker run options (see below).
+Notice that these are arguments for the container Entrypoint, not extra docker run options (see below).
 
 #### Extra `docker run` Options
 
@@ -93,9 +93,9 @@ docker run {docker-run-options} {service-options} mysql/mysql-server
 
 Where `{docker-run-options}` are the options you specify inside the `--run` option and `{service-options}` are generated based on the default options for that service.
 
-#### Mixing `docker run` Options With Container Options
+#### Mixing `docker run` Options With Container Arguments
 
-You may mix and match the `run` options with the container options:
+You may mix and match the `run` options with the container arguments:
 
 ```bash
 takeout enable mysql --run="{docker-run-options}" -- -hsome.mysql.host -usome-user

--- a/README.md
+++ b/README.md
@@ -67,6 +67,40 @@ takeout enable mysql --default
 takeout enable redis meilisearch --default
 ```
 
+#### Passthrough Container Arguments
+
+You may specify extra arguments to the container after a `--` sepatator:
+
+```bash
+takeout enable mysql -- -hsome.mysql.host -usome-user
+```
+
+Notice that these are options for the container (arguments), not extra docker run options (see below).
+
+#### Extra `docker run` Options
+
+Under the hood, the `takeout enable` command generates a `docker run` command. Sometimes you may want to specify extra options to the `docker run` command such as an extra environment variable or an extra volume mapping. You can pass a string with all the extra `docker run` options using the `--run=` option:
+
+```bash
+takeout enable mysql --run="{docker-run-options}"
+```
+
+Which would generate the following command:
+
+```bash
+docker run {docker-run-options} {service-options} mysql/mysql-server
+```
+
+Where `{docker-run-options}` are the options you specify inside the `--run` option and `{service-options}` are generated based on the default options for that service.
+
+#### Mixing `docker run` Options With Container Options
+
+You may mix and match the `run` options with the container options:
+
+```bash
+takeout enable mysql --run="{docker-run-options}" -- -hsome.mysql.host -usome-user
+```
+
 ### Disable a service
 
 Show a list of all enabled services you can disable.

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -16,7 +16,7 @@ class EnableCommand extends Command
 
     const MENU_TITLE = 'Takeout containers to enable';
 
-    protected $signature = 'enable {serviceNames?*} {--default}';
+    protected $signature = 'enable {serviceNames?*} {--default} {--run}';
     protected $description = 'Enable services.';
     protected $environment;
     protected $services;
@@ -31,10 +31,16 @@ class EnableCommand extends Command
         $passthroughOptions = $this->extractPassthroughOptions($this->serverArguments());
 
         $useDefaults = $this->option('default');
+        $runOptions = $this->option('run');
 
         if (filled($services)) {
+            if ($runOptions && is_array($services) && count($services) > 1) {
+                $this->error('The --run options should only be used for enabling a single service.');
+                return;
+            }
+
             foreach ($services as $service) {
-                $this->enable($service, $useDefaults, $passthroughOptions);
+                $this->enable($service, $useDefaults, $passthroughOptions, $runOptions);
             }
 
             return;
@@ -61,6 +67,10 @@ class EnableCommand extends Command
 
             if ($this->option('default')) {
                 $string[] = '--default';
+            }
+
+            if ($this->option('run')) {
+                $string[] = '--run';
             }
 
             return $string;
@@ -205,9 +215,9 @@ class EnableCommand extends Command
             ->toArray();
     }
 
-    public function enable(string $service, bool $useDefaults = false, array $passthroughOptions = []): void
+    public function enable(string $service, bool $useDefaults = false, array $passthroughOptions = [], string $runOptions = null): void
     {
         $fqcn = $this->services->get($service);
-        app($fqcn)->enable($useDefaults, $passthroughOptions);
+        app($fqcn)->enable($useDefaults, $passthroughOptions, $runOptions);
     }
 }

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -16,7 +16,7 @@ class EnableCommand extends Command
 
     const MENU_TITLE = 'Takeout containers to enable';
 
-    protected $signature = 'enable {serviceNames?*} {--default} {--run}';
+    protected $signature = 'enable {serviceNames?*} {--default} {--run= : Pass any extra docker run options.}';
     protected $description = 'Enable services.';
     protected $environment;
     protected $services;

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -79,8 +79,11 @@ abstract class BaseService
 
         try {
             $this->docker->bootContainer(
-                join(' ', array_filter([$this->sanitizeDockerRunTemplate($this->dockerRunTemplate), $this->buildPassthroughOptionsString($passthroughOptions)])),
-                $this->buildParameters()
+                join(' ', array_filter([
+                    $this->sanitizeDockerRunTemplate($this->dockerRunTemplate),
+                    $this->buildPassthroughOptionsString($passthroughOptions),
+                ])),
+                $this->buildParameters(),
             );
 
             $this->info("\nService enabled!");

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -79,7 +79,7 @@ abstract class BaseService
 
         try {
             $this->docker->bootContainer(
-                join(' ', array_filter([$this->buildPassthroughOptionsString($passthroughOptions), $this->sanitizeDockerRunTemplate($this->dockerRunTemplate)])),
+                join(' ', array_filter([$this->sanitizeDockerRunTemplate($this->dockerRunTemplate), $this->buildPassthroughOptionsString($passthroughOptions)])),
                 $this->buildParameters()
             );
 

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -67,7 +67,7 @@ abstract class BaseService
         return static::$displayName ?? Str::afterLast(static::class, '\\');
     }
 
-    public function enable(bool $useDefaults = false, array $passthroughOptions = []): void
+    public function enable(bool $useDefaults = false, array $passthroughOptions = [], string $runOptions = null): void
     {
         $this->useDefaults = $useDefaults;
 
@@ -80,6 +80,7 @@ abstract class BaseService
         try {
             $this->docker->bootContainer(
                 join(' ', array_filter([
+                    $runOptions,
                     $this->sanitizeDockerRunTemplate($this->dockerRunTemplate),
                     $this->buildPassthroughOptionsString($passthroughOptions),
                 ])),

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,15 @@
             "ext-posix": "7.2"
         }
     },
+    "scripts": {
+        "lint:check": [
+            "tlint",
+            "phpcs"
+        ],
+        "lint:fix": [
+            "phpcbf"
+        ]
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "bin": ["builds/takeout"]

--- a/tests/Feature/BaseServiceTest.php
+++ b/tests/Feature/BaseServiceTest.php
@@ -2,16 +2,14 @@
 
 namespace Tests\Feature;
 
-use App\Services\BaseService;
-use App\Services\Category;
 use App\Services\MeiliSearch;
 use App\Services\PostgreSql;
 use App\Shell\Docker;
-use App\Shell\DockerTags;
 use App\Shell\Shell;
 use LaravelZero\Framework\Commands\Command;
 use Mockery as M;
 use Symfony\Component\Process\Process;
+use Tests\Support\FakeService;
 use Tests\TestCase;
 
 class BaseServiceTest extends TestCase
@@ -117,7 +115,7 @@ class BaseServiceTest extends TestCase
     /** @test */
     public function it_can_receive_container_arguments_via_passthrough()
     {
-        $service = app(TestService::class);
+        $service = app(FakeService::class);
         $passthroughOptions = ['-h=127.0.0.1', '-usome-user'];
 
         app()->instance('console', M::mock(Command::class, function ($mock) use ($service) {
@@ -151,21 +149,21 @@ class BaseServiceTest extends TestCase
                     'image_name' => '_test_image',
                     'port' => 12345,
                     'tag' => 'latest',
-                    'container_name' => 'TO--testservice--latest--12345',
-                    'alias' => 'testservice-latest',
+                    'container_name' => 'TO--fakeservice--latest--12345',
+                    'alias' => 'fakeservice-latest',
                 ]
             )->once();
         });
 
         // We need to create a new instance of the service so it can use the mocked objects...
-        $service = app(TestService::class);
+        $service = app(FakeService::class);
         $service->enable(passthroughOptions: $passthroughOptions);
     }
 
     /** @test */
     public function it_accepts_run_options_and_passthrough_options()
     {
-        $service = app(TestService::class);
+        $service = app(FakeService::class);
         $passthroughOptions = ['-h=127.0.0.1', '-usome-user'];
         $runOptions = '--restart unless-stopped -e "LOREM=IPSUM"';
 
@@ -201,34 +199,14 @@ class BaseServiceTest extends TestCase
                     'image_name' => '_test_image',
                     'port' => 12345,
                     'tag' => 'latest',
-                    'container_name' => 'TO--testservice--latest--12345',
-                    'alias' => 'testservice-latest',
+                    'container_name' => 'TO--fakeservice--latest--12345',
+                    'alias' => 'fakeservice-latest',
                 ]
             )->once();
         });
 
         // We need to create a new instance of the service so it can use the mocked objects...
-        $service = app(TestService::class);
+        $service = app(FakeService::class);
         $service->enable(passthroughOptions: $passthroughOptions, runOptions: $runOptions);
-    }
-}
-
-class TestService extends BaseService
-{
-    protected static $category = Category::CACHE;
-    protected $dockerTagsClass = FakeDockerTags::class;
-
-    protected $organization = 'tighten';
-    protected $imageName = '_test_image';
-    protected $defaultPort = 12345;
-
-    protected $dockerRunTemplate = '"${:organization}"/"${:image_name}":"${:tag}"';
-}
-
-class FakeDockerTags
-{
-    public function resolveTag($tag)
-    {
-        return $tag;
     }
 }

--- a/tests/Feature/BaseServiceTest.php
+++ b/tests/Feature/BaseServiceTest.php
@@ -147,12 +147,12 @@ class BaseServiceTest extends TestCase
                     $service->buildPassthroughOptionsString($passthroughOptions),
                 ]),
                 [
-                    "organization" => "tighten",
-                    "image_name" => "_test_image",
-                    "port" => 12345,
-                    "tag" => "latest",
-                    "container_name" => "TO--testservice--latest--12345",
-                    "alias" => "testservice-latest",
+                    'organization' => 'tighten',
+                    'image_name' => '_test_image',
+                    'port' => 12345,
+                    'tag' => 'latest',
+                    'container_name' => 'TO--testservice--latest--12345',
+                    'alias' => 'testservice-latest',
                 ]
             )->once();
         });
@@ -197,12 +197,12 @@ class BaseServiceTest extends TestCase
                     $service->buildPassthroughOptionsString($passthroughOptions),
                 ]),
                 [
-                    "organization" => "tighten",
-                    "image_name" => "_test_image",
-                    "port" => 12345,
-                    "tag" => "latest",
-                    "container_name" => "TO--testservice--latest--12345",
-                    "alias" => "testservice-latest",
+                    'organization' => 'tighten',
+                    'image_name' => '_test_image',
+                    'port' => 12345,
+                    'tag' => 'latest',
+                    'container_name' => 'TO--testservice--latest--12345',
+                    'alias' => 'testservice-latest',
                 ]
             )->once();
         });

--- a/tests/Feature/ServiceEnableDefaultTest.php
+++ b/tests/Feature/ServiceEnableDefaultTest.php
@@ -31,7 +31,7 @@ class ServiceEnableDefaultTest extends TestCase
 
         $service = 'mailhog';
         $this->mock(MailHog::class, function ($mock) use ($service) {
-            $mock->shouldReceive('enable')->with(true, [])->twice();
+            $mock->shouldReceive('enable')->with(true, [], null)->twice();
             $mock->shouldReceive('shortName')->andReturn($service);
         });
 
@@ -47,6 +47,52 @@ class ServiceEnableDefaultTest extends TestCase
         $this->artisan('enable ' . $service . ' --default');
 
         $service = app(MailHog::class); // Extends BaseService
-        $service->enable(true, []);
+        $service->enable(true, [], null);
+    }
+
+    /** @test */
+    public function can_enable_with_run_options()
+    {
+        $runOptions = '--restart unless-stopped -e "LOREM=IPSUM"';
+        app()->instance('console', M::mock(Command::class, function ($mock) {
+            $defaultPort = app(MailHog::class)->defaultPort();
+            $mock->shouldReceive('ask')->with('Which host port would you like this service to use?', $defaultPort)->andReturn(7700);
+            $mock->shouldReceive('ask')->with('Which host port would you like this service to use?', $defaultPort)->andReturn(77001);
+            $mock->shouldReceive('ask')->with('Which tag (version) of this service would you like to use?', 'latest')->andReturn('latest');
+            $mock->shouldIgnoreMissing();
+        }));
+
+        $this->mock(Shell::class, function ($mock) {
+            $process = M::mock(Process::class);
+            $process->shouldReceive('isSuccessful')->andReturn(true);
+            $process->shouldReceive('isSuccessful')->andReturn(false);
+            $process->shouldReceive('getOutput')->andReturn('');
+
+            $mock->shouldReceive('execQuietly')->andReturn($process);
+        });
+
+        $service = 'mailhog';
+        $this->mock(MailHog::class, function ($mock) use ($service, $runOptions) {
+            $mock->shouldReceive('enable')->with(true, [], $runOptions)->twice();
+            $mock->shouldReceive('shortName')->andReturn($service);
+        });
+
+        $this->mock(Docker::class, function ($mock) {
+            $mock->shouldReceive('isInstalled')->andReturn(true);
+            $mock->shouldReceive('isDockerServiceRunning')->andReturn(true);
+            $mock->shouldReceive('imageIsDownloaded')->andReturn(true);
+
+            // This is the actual assertion
+            $mock->shouldReceive('bootContainer')->with(['mailhog/mailhog']);
+        });
+
+        $this->artisan('enable', [
+            'serviceNames' => [$service],
+            '--default' => true,
+            '--run' => $runOptions,
+        ]);
+
+        $service = app(MailHog::class); // Extends BaseService
+        $service->enable(true, [], $runOptions);
     }
 }

--- a/tests/Support/FakeDockerTags.php
+++ b/tests/Support/FakeDockerTags.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Support;
+
+class FakeDockerTags
+{
+    public function resolveTag($tag)
+    {
+        return $tag;
+    }
+}

--- a/tests/Support/FakeService.php
+++ b/tests/Support/FakeService.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Services\BaseService;
+use App\Services\Category;
+
+class FakeService extends BaseService
+{
+    protected static $category = Category::CACHE;
+    protected $dockerTagsClass = FakeDockerTags::class;
+
+    protected $organization = 'tighten';
+    protected $imageName = '_test_image';
+    protected $defaultPort = 12345;
+
+    protected $dockerRunTemplate = '"${:organization}"/"${:image_name}":"${:tag}"';
+}

--- a/tests/Support/FakeService.php
+++ b/tests/Support/FakeService.php
@@ -8,11 +8,10 @@ use App\Services\Category;
 class FakeService extends BaseService
 {
     protected static $category = Category::CACHE;
-    protected $dockerTagsClass = FakeDockerTags::class;
 
+    protected $dockerTagsClass = FakeDockerTags::class;
     protected $organization = 'tighten';
     protected $imageName = '_test_image';
     protected $defaultPort = 12345;
-
     protected $dockerRunTemplate = '"${:organization}"/"${:image_name}":"${:tag}"';
 }


### PR DESCRIPTION
### Changed

- Reverts the passthrough options to be container arguments instead of docker run options (https://github.com/tighten/takeout/pull/302)

### Added

- Adds a new `--run` option to the enable command which can be used to pass any extra docker run option

---

This is how we can use this:

```bash
takeout enable mysql --run="--restart unless-stopped -e 'LOREM=IPSUM'" -- -h127.0.0.1 -usome-user
```

This will be translated to a docker command like this:

```bash
docker run --restart unless-stopped -e 'LOREM=IPSUM' {service-options} mysql -h127.0.0.1 -usome-user
```

where `{service-options}` depends on the options defined in the service class.