### PR TITLE
Adds a Docker setup for building the final phar file to ensure dependencies are pulled for PHP 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM composer:latest AS composer
+
+FROM php:8.0-cli
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+RUN apt-get update && apt-get install -y git

--- a/README.md
+++ b/README.md
@@ -231,15 +231,28 @@ The best way to see our future plans is to check out the [Projects Board](https:
 
 ## Process for release
 
-If you're working with us and are assigned to push a release, here's the easiest process:
+If you're working with us and are assigned to push a release, here's the process to do so.
 
+Before we start, visit the [Takeout Releases page](https://github.com/tighten/takeout/releases); figure out what your next tag will be (increase the third number if it's a patch or fix; increase the second number if it's adding features).
 
-1. Visit the [Takeout Releases page](https://github.com/tighten/takeout/releases); figure out what your next tag will be (increase the third number if it's a patch or fix; increase the second number if it's adding features)
-2. On your local machine, pull down the latest version of `main` (`git checkout main && git pull`)
-3. Build for the version you're targeting (`php ./takeout app:build`)
-4. Run the build once to make sure it works (`php ./builds/takeout list`)
-5. Commit your build and push it up
-6. [Draft a new release](https://github.com/tighten/takeout/releases/new) with both the tag version and release title of your tag (e.g. `v1.5.1`)
-7. Use the "Generate release notes" button to generate release notes from the merged PRs.
-8. Hit `Publish release`
-9. Profit 😆
+### Building From Your Local Machin
+1. Ensure you're on PHP 8.0.x (so all the dependencies resolved with Composer work with that version)
+1. Pull down the latest version of `main` (`git checkout main && git pull`)
+1. Pull the composer dependencies from that PHP version (`rm -rf vendor/ composer.lock && composer install`)
+1. Build for the version you're targeting (`php ./takeout app:build`)
+1. Run the build once to make sure it works (`php ./builds/takeout list`)
+1. Commit your build and push it up
+1. [Draft a new release](https://github.com/tighten/takeout/releases/new) with both the tag version and release title of your tag (e.g. `v1.5.1`)
+1. Use the "Generate release notes" button to generate release notes from the merged PRs.
+1. Hit `Publish release`
+1. Profit 😆
+
+### Building From Docker
+1. Ensure you have [Docker installed](https://docs.docker.com/get-docker/)
+1. Run `./bin/build.sh`
+1. Run the build once to make sure it works (`php ./builds/takeout list`)
+1. Commit your build and push it up
+1. [Draft a new release](https://github.com/tighten/takeout/releases/new) with both the tag version and release title of your tag (e.g. `v1.5.1`)
+1. Use the "Generate release notes" button to generate release notes from the merged PRs.
+1. Hit `Publish release`
+1. Profit 😆

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ If you're working with us and are assigned to push a release, here's the process
 
 Before we start, visit the [Takeout Releases page](https://github.com/tighten/takeout/releases); figure out what your next tag will be (increase the third number if it's a patch or fix; increase the second number if it's adding features).
 
-### Building From Your Local Machin
+### Building From Your Local Machine
 1. Ensure you're on PHP 8.0.x (so all the dependencies resolved with Composer work with that version)
 1. Pull down the latest version of `main` (`git checkout main && git pull`)
 1. Pull the composer dependencies from that PHP version (`rm -rf vendor/ composer.lock && composer install`)

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Ensure the tighten/takeout-builder docker image is up-to-date with the Dockerfile...
+docker buildx build . -t tighten/takeout-builder
+
+# Create the composer cache volumes to speed things up a bit on subsequent builds...
+docker volume create takeout-build-composer-local-cache
+docker volume create takeout-build-composer-global-cache
+
+# We need to ensure the vendor/ folder and the composer.lock are not
+# present so we can get a clean dependencies install...
+rm -rf vendor/ composer.lock
+
+# Pull dependencies using the correct PHP version and build!
+docker run --rm -it \
+    -v $PWD:/app \
+    -v takeout-build-composer-local-cache:/app/vendor \
+    -v takeout-build-composer-global-cache:/composer \
+    -w /app \
+    -e COMPOSER_HOME=/composer \
+    tighten/takeout-builder bash -c "composer install && php ./takeout app:build"

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,9 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "optimize-autoloader": true,
-        "platform-check": false,
+        "platform-check": true,
         "platform": {
+            "php": "8.0.2",
             "ext-pcntl": "7.2",
             "ext-posix": "7.2"
         }


### PR DESCRIPTION
### Fixed

- Fixes `phar` file generated from latest PHP version (and Composer dependencies also pulled from those versions) don't work when running takeout with PHP 8.0 (supported) by adding a `bin/build.sh` script that pulls dependencies and builds the `phar` file inside a Docker container

---

issue https://github.com/tighten/takeout/issues/296