### PR TITLE
Ensure Composer dependencies are compatible with PHP 8.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-req=ext-pcntl
+              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-req=ext-pcntl --ignore-platform-req=ext-posix
 
             - name: Run tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,22 +39,15 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v1
 
-            # - name: Cache dependencies
-            #   uses: actions/cache@v1
-            #   with:
-            #       path: ~/.composer/cache/files
-            #       key: dependencies-os-${{ matrix.os }}-php-${{ matrix.php }}-laravel-${{ matrix.laravel-version }}-composer-${{ hashFiles('**/composer.lock') }}
-            #       restore-keys: dependencies-os-${{ matrix.os }}-php-${{ matrix.php }}-laravel-${{ matrix.laravel-version }}
-
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+                  extensions: posix, dom, curl, libxml, fileinfo, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
                   coverage: none
 
             - name: Install dependencies
-              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-req=ext-fileinfo
+              run: composer update --prefer-stable --prefer-dist --no-interaction
 
             - name: Run tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-reqs=ext-pcntl
+              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-req=ext-pcntl
 
             - name: Run tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: composer update --prefer-stable --prefer-dist --no-interaction
+              run: composer update --prefer-stable --prefer-dist --no-interaction --ignore-platform-reqs=ext-pcntl
 
             - name: Run tests
               run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "optimize-autoloader": true,
-        "platform-check": false,
+        "platform-check": true,
         "platform": {
             "php": "8.0.2"
         }

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "optimize-autoloader": true,
-        "platform-check": true,
+        "platform-check": false,
         "platform": {
             "php": "8.0.2"
         }

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,9 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "optimize-autoloader": true,
-        "platform-check": false,
+        "platform-check": true,
         "platform": {
+            "php": "8.0.2",
             "ext-pcntl": "7.2",
             "ext-posix": "7.2"
         }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
+        "ext-pcntl": "*",
+        "ext-posix": "*",
         "guzzlehttp/psr7": "^1.7"
     },
     "require-dev": {
@@ -48,9 +50,7 @@
         "optimize-autoloader": true,
         "platform-check": true,
         "platform": {
-            "php": "8.0.2",
-            "ext-pcntl": "7.2",
-            "ext-posix": "7.2"
+            "php": "8.0.2"
         }
     },
     "scripts": {


### PR DESCRIPTION
### Fixed

- Fixes `phar` file not compatible with PHP 8.0 when pulling the Composer dependencies and building from a higher PHP version

---

issues #296 