### PR TITLE
Update MailDev image tag, ports and template

### DIFF
--- a/app/Services/MailDev.php
+++ b/app/Services/MailDev.php
@@ -18,18 +18,18 @@ class MailDev extends BaseService
         [
             'shortname' => 'tag',
             'prompt' => 'Which tag (version) of %s would you like to use?',
-            'default' => '1.1.0',
+            'default' => '2.0.5',
         ],
     ];
     protected $prompts = [
         [
             'shortname' => 'web_port',
             'prompt' => 'What will the web port be?',
-            'default' => '8025',
+            'default' => '1080',
         ],
     ];
 
-    protected $dockerRunTemplate = '-p "${:port}":25 \
-        -p "${:web_port}":80 \
+    protected $dockerRunTemplate = '-p "${:port}":1025 \
+        -p "${:web_port}":1080 \
         "${:organization}"/"${:image_name}":"${:tag}"';
 }


### PR DESCRIPTION
### Changed

- Updated default image tag for maildev
- Changed ports used by maildev image

---
MailDev has released a new major version that has a breaking change in the ports exposed by the docker image. With this new major version they have also introduced ARM image support, helpful for us running on newer macs.
