### PR TITLE
EventStoredB: use latest version, pass in params for local dev

### DIFF
--- a/app/Services/EventStoreDB.php
+++ b/app/Services/EventStoreDB.php
@@ -26,18 +26,6 @@ class EventStoreDB extends BaseService
         ],
     ];
 
-    public function __construct(Shell $shell, Environment $environment, Docker $docker)
-    {
-        parent::__construct($shell, $environment, $docker);
-
-        $this->defaultPrompts = array_map(function ($prompt) {
-            if ($prompt['shortname'] === 'tag') {
-                $prompt['default'] = '5.0.8-xenial';
-            }
-            return $prompt;
-        }, $this->defaultPrompts);
-    }
-
     /**
      * The following only supports version 5.X.
      *
@@ -47,5 +35,7 @@ class EventStoreDB extends BaseService
     protected $dockerRunTemplate = '-p "${:port}":1113 \
         -p "${:web_port}":2113 \
         -v "${:volume}":/var/lib/eventstore \
-        "${:organization}"/"${:image_name}":"${:tag}"';
+        "${:organization}"/"${:image_name}":"${:tag}" \
+        --insecure --run-projections=All \
+        --enable-external-tcp --enable-atom-pub-over-http';
 }

--- a/app/Services/EventStoreDB.php
+++ b/app/Services/EventStoreDB.php
@@ -2,10 +2,6 @@
 
 namespace App\Services;
 
-use App\Shell\Docker;
-use App\Shell\Environment;
-use App\Shell\Shell;
-
 class EventStoreDB extends BaseService
 {
     protected static $category = Category::DATABASE;

--- a/app/Services/EventStoreDB.php
+++ b/app/Services/EventStoreDB.php
@@ -26,12 +26,6 @@ class EventStoreDB extends BaseService
         ],
     ];
 
-    /**
-     * The following only supports version 5.X.
-     *
-     * 20.6.0 requires various env variables to be set and forces HTTPS which is a pain in local dev.
-     * 20.6.1 can disable HTTPS but there's no auth which means most features are disabled.
-     */
     protected $dockerRunTemplate = '-p "${:port}":1113 \
         -p "${:web_port}":2113 \
         -v "${:volume}":/var/lib/eventstore \


### PR DESCRIPTION
Since #154 , EventStore has improved the local DX. This PR reverts to use the latest version - which to my benefit will auto-select the arm version on my mac, love it! 