### PR TITLE
Set the default tag to latest-16-alpine, same one as Sail uses

### DIFF
--- a/app/Services/Soketi.php
+++ b/app/Services/Soketi.php
@@ -26,7 +26,7 @@ class Soketi extends BaseService
 
     protected $dockerRunTemplate = '-p "${:port}":6001 \
         -p "${:metrics_port}":9601 \
-        -e METRICS_ENABLED=1 \
+        -e SOKETI_METRICS_ENABLED=1 \
         "${:organization}"/"${:image_name}":"${:tag}"';
 
     public function __construct(Shell $shell, Environment $environment, Docker $docker)

--- a/app/Services/Soketi.php
+++ b/app/Services/Soketi.php
@@ -2,7 +2,10 @@
 
 namespace App\Services;
 
+use App\Shell\Docker;
+use App\Shell\Environment;
 use App\Shell\QuayDockerTags;
+use App\Shell\Shell;
 
 class Soketi extends BaseService
 {
@@ -11,7 +14,7 @@ class Soketi extends BaseService
     protected $dockerTagsClass = QuayDockerTags::class;
     protected $organization = 'quay.io';
     protected $imageName = 'soketi/soketi';
-    protected $tag = 'latest';
+    protected $tag = 'latest-16-alpine';
     protected $defaultPort = 6001;
     protected $prompts = [
         [
@@ -25,4 +28,17 @@ class Soketi extends BaseService
         -p "${:metrics_port}":9601 \
         -e METRICS_ENABLED=1 \
         "${:organization}"/"${:image_name}":"${:tag}"';
+
+    public function __construct(Shell $shell, Environment $environment, Docker $docker)
+    {
+        parent::__construct($shell, $environment, $docker);
+
+        $this->defaultPrompts = array_map(function ($prompt) {
+            if ($prompt['shortname'] === 'tag') {
+                $prompt['default'] = $this->tag;
+            }
+
+            return $prompt;
+        }, $this->defaultPrompts);
+    }
 }


### PR DESCRIPTION
### Fixed

- Sets the default tag to `latest-16-alpine`, same one as Sail uses (see [here](https://github.com/laravel/sail/blob/1.x/stubs/soketi.stub)) to fix the issue described at #318 

---

Fixes #318 