### PR TITLE
fix issue #329

### DIFF
--- a/app/Services/MySql.php
+++ b/app/Services/MySql.php
@@ -6,8 +6,7 @@ class MySql extends BaseService
 {
     protected static $category = Category::DATABASE;
 
-    protected $organization = 'mysql';
-    protected $imageName = 'mysql-server';
+    protected $imageName = 'mysql';
     protected $defaultPort = 3306;
     protected $prompts = [
         [

--- a/app/Services/MySql.php
+++ b/app/Services/MySql.php
@@ -7,7 +7,9 @@ class MySql extends BaseService
     protected static $category = Category::DATABASE;
 
     protected $imageName = 'mysql';
+
     protected $defaultPort = 3306;
+
     protected $prompts = [
         [
             'shortname' => 'volume',


### PR DESCRIPTION
Make use of offical mysql docker image which includes latest versions 8.2 and 8.0.35.

remove variable `$organization` will default to string `library` which is used as `$organization` when pull official images.

fix #329