### PR TITLE
Add Typesense service class

### DIFF
--- a/app/Services/Typesense.php
+++ b/app/Services/Typesense.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services;
+
+class Typesense extends BaseService
+{
+    protected static $category = Category::SEARCH;
+
+    protected $organization = 'typesense';
+    protected $imageName = 'typesense';
+    protected $defaultPort = 8108;
+    protected $prompts = [
+        [
+            'shortname' => 'volume',
+            'prompt' => 'What is the Docker volume name?',
+            'default' => 'typesense_data',
+        ],
+        [
+            'shortname' => 'admin_key',
+            'prompt' => 'What will the admin API key be?',
+            'default' => 'typesenseadmin',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "${:port}":8108 \
+        -v "${:volume}":/data \
+        "${:organization}"/"${:image_name}":"${:tag}" \
+        --data-dir /data \
+        --api-key="${:admin_key}"';
+
+    protected static $displayName = 'Typesense';
+}


### PR DESCRIPTION
This is my first contribution here -- please let me know if I've missed something.

### Added
- Typesense service option via Takeout

Saw [this old issue](https://github.com/tighten/takeout/issues/303) and was inspired by todays [Laravel News article](https://laravel-news.com/laravel-scout-typesense) about Typesense getting added to Scout.

