### PR TITLE
Enforce the version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ But you can also easily enable ElasticSearch, PostgreSQL, MSSQL, Mongo, Redis, a
 Install Takeout with Composer by running:
 
 ```bash
-composer global require tightenco/takeout
+composer global require tightenco/takeout:~2.5
 ```
 
 Make sure the `~/.composer/vendor/bin` directory is in your system's "PATH".


### PR DESCRIPTION
### Changed

- Enforce the latest version in the install command to avoid issues like #314 and #323

---

closes https://github.com/tighten/takeout/issues/323

hat tip to @cheesegrits for the suggestion [here](https://github.com/tighten/takeout/issues/314#issuecomment-1622430535). 