### PR TITLE
Adds Buggregator as a tool

### DIFF
--- a/app/Services/Buggregator.php
+++ b/app/Services/Buggregator.php
@@ -29,12 +29,17 @@ class Buggregator extends BaseService
             'prompt' => 'What is the Monolog port?',
             'default' => '9913',
         ],
+        [
+            'shortname' => 'network_alias',
+            'prompt' => 'What network alias to you want to assign to this container? This alias can be used by other services on the same network.',
+            'default' => 'dump-server',
+        ],
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":8000 \
         -p "${:smtp_port}":1025 \
         -p "${:var_dumper_port}":9912 \
         -p "${:monolog_port}":9913 \
-        --network-alias dump-server \
+        --network-alias "${:network_alias}" \
         "${:organization}"/"${:image_name}":"${:tag}"';
 }

--- a/app/Services/Buggregator.php
+++ b/app/Services/Buggregator.php
@@ -32,7 +32,7 @@ class Buggregator extends BaseService
         [
             'shortname' => 'network_alias',
             'prompt' => 'What network alias to you want to assign to this container? This alias can be used by other services on the same network.',
-            'default' => 'dump-server',
+            'default' => 'buggregator',
         ],
     ];
 

--- a/app/Services/Buggregator.php
+++ b/app/Services/Buggregator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Shell\GitHubDockerTags;
+
+class Buggregator extends BaseService
+{
+    protected static $category = Category::TOOLS;
+
+    protected $dockerTagsClass = GitHubDockerTags::class;
+    protected $organization = 'ghcr.io';
+    protected $imageName = 'buggregator/server';
+    protected $tag = 'latest';
+    protected $defaultPort = 8000;
+    protected $prompts = [
+        [
+            'shortname' => 'smtp_port',
+            'prompt' => 'What is the SMTP port?',
+            'default' => '1025',
+        ],
+        [
+            'shortname' => 'var_dumper_port',
+            'prompt' => 'What is the VarDumper server port?',
+            'default' => '9912',
+        ],
+        [
+            'shortname' => 'monolog_port',
+            'prompt' => 'What is the Monolog port?',
+            'default' => '9913',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "${:port}":8000 \
+        -p "${:smtp_port}":1025 \
+        -p "${:var_dumper_port}":9912 \
+        -p "${:monolog_port}":9913 \
+        --network-alias dump-server \
+        "${:organization}"/"${:image_name}":"${:tag}"';
+}

--- a/app/Shell/GitHubDockerTags.php
+++ b/app/Shell/GitHubDockerTags.php
@@ -26,6 +26,11 @@ class GitHubDockerTags extends DockerTags
         return collect(json_decode($this->getTagsResponse(), true)['tags']);
     }
 
+    public function getLatestTag(): string
+    {
+        return $this->getTags()->first();
+    }
+
     protected function getToken(): string
     {
         $image = $this->service->imageName();

--- a/app/Shell/GitHubDockerTags.php
+++ b/app/Shell/GitHubDockerTags.php
@@ -35,7 +35,7 @@ class GitHubDockerTags extends DockerTags
     {
         $image = $this->service->imageName();
 
-        $response = $this->guzzle->get("https://ghcr.io/token?" . http_build_query([
+        $response = $this->guzzle->get('https://ghcr.io/token?' . http_build_query([
             'scope' => "repository:{$image}:pull",
         ]));
 

--- a/app/Shell/GitHubDockerTags.php
+++ b/app/Shell/GitHubDockerTags.php
@@ -38,7 +38,7 @@ class GitHubDockerTags extends DockerTags
         $response = $this->guzzle->get('https://ghcr.io/token?' . http_build_query([
             'scope' => "repository:{$image}:pull",
         ]), [
-            "http_errors" => false,
+            'http_errors' => false,
         ]);
 
         if ($response->getStatusCode() !== 200) {

--- a/app/Shell/GitHubDockerTags.php
+++ b/app/Shell/GitHubDockerTags.php
@@ -8,6 +8,16 @@ use RuntimeException;
 
 class GitHubDockerTags extends DockerTags
 {
+    public function getTags(): Collection
+    {
+        return collect(json_decode($this->getTagsResponse(), true)['tags']);
+    }
+
+    public function getLatestTag(): string
+    {
+        return $this->getTags()->first();
+    }
+
     protected function getTagsResponse(): StreamInterface
     {
         $token = $this->getToken();
@@ -19,16 +29,6 @@ class GitHubDockerTags extends DockerTags
                 ],
             ])
             ->getBody();
-    }
-
-    public function getTags(): Collection
-    {
-        return collect(json_decode($this->getTagsResponse(), true)['tags']);
-    }
-
-    public function getLatestTag(): string
-    {
-        return $this->getTags()->first();
     }
 
     protected function getToken(): string

--- a/app/Shell/GitHubDockerTags.php
+++ b/app/Shell/GitHubDockerTags.php
@@ -37,7 +37,9 @@ class GitHubDockerTags extends DockerTags
 
         $response = $this->guzzle->get('https://ghcr.io/token?' . http_build_query([
             'scope' => "repository:{$image}:pull",
-        ]));
+        ]), [
+            "http_errors" => false,
+        ]);
 
         if ($response->getStatusCode() !== 200) {
             throw new RuntimeException("Something went wrong getting the Token from GitHub's registry.");

--- a/app/Shell/GitHubDockerTags.php
+++ b/app/Shell/GitHubDockerTags.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Shell;
+
+use Illuminate\Support\Collection;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+class GitHubDockerTags extends DockerTags
+{
+    protected function getTagsResponse(): StreamInterface
+    {
+        $token = $this->getToken();
+
+        return $this->guzzle
+            ->get($this->buildTagsUrl(), [
+                'headers' => [
+                    'Authorization' => "Bearer {$token}",
+                ],
+            ])
+            ->getBody();
+    }
+
+    public function getTags(): Collection
+    {
+        return collect(json_decode($this->getTagsResponse(), true)['tags']);
+    }
+
+    protected function getToken(): string
+    {
+        $image = $this->service->imageName();
+
+        $response = $this->guzzle->get("https://ghcr.io/token?" . http_build_query([
+            'scope' => "repository:{$image}:pull",
+        ]));
+
+        if ($response->getStatusCode() !== 200) {
+            throw new RuntimeException("Something went wrong getting the Token from GitHub's registry.");
+        }
+
+        return json_decode($response->getBody(), true)['token'];
+    }
+
+    protected function tagsUrlTemplate(): string
+    {
+        return 'https://%s/v2/%s/tags/list';
+    }
+}

--- a/tests/Feature/GitHubTagsTest.php
+++ b/tests/Feature/GitHubTagsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\Buggregator;
+use App\Shell\DockerTags;
+use App\Shell\GitHubDockerTags;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Mockery as M;
+use RuntimeException;
+use Tests\TestCase;
+
+class GitHubTagsTest extends TestCase
+{
+    /** @test */
+    function it_fetches_latest_tag()
+    {
+        $handlerStack = HandlerStack::create($this->mockImagesResponseHandler());
+        $client = new Client(['handler' => $handlerStack]);
+
+        /** @var DockerTags $dockerTags */
+        $dockerTags = M::mock(GitHubDockerTags::class, [$client, app(Buggregator::class)])->makePartial();
+
+        $this->assertEquals('latest', $dockerTags->getLatestTag());
+    }
+
+    /** @test */
+    function it_throws_exception_when_token_request_fails()
+    {
+        $handlerStack = HandlerStack::create($this->mockImagesResponseHandler(false));
+        $client = new Client(['handler' => $handlerStack]);
+
+        /** @var DockerTags $dockerTags */
+        $dockerTags = M::mock(GitHubDockerTags::class, [$client, app(Buggregator::class)])->makePartial();
+
+        $this->expectException(RuntimeException::class);
+
+        $dockerTags->getLatestTag();
+    }
+
+    private function mockImagesResponseHandler($tokenWorks = true)
+    {
+        return new MockHandler([
+            new Response($tokenWorks ? 200 : 400, [], json_encode([
+                'token' => 'fake-token',
+            ])),
+            new Response(200, [], json_encode([
+                'tags' => [
+                    'latest',
+                    '1.0.0',
+                    '1.0.0.rc-1',
+                ],
+            ])),
+        ]);
+    }
+}

--- a/tests/Feature/GitHubTagsTest.php
+++ b/tests/Feature/GitHubTagsTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Services\Buggregator;
-use App\Shell\DockerTags;
 use App\Shell\GitHubDockerTags;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -21,7 +20,7 @@ class GitHubTagsTest extends TestCase
         $handlerStack = HandlerStack::create($this->mockImagesResponseHandler());
         $client = new Client(['handler' => $handlerStack]);
 
-        /** @var DockerTags $dockerTags */
+        /** @var GitHubDockerTags $dockerTags */
         $dockerTags = M::mock(GitHubDockerTags::class, [$client, app(Buggregator::class)])->makePartial();
 
         $this->assertEquals('latest', $dockerTags->getLatestTag());
@@ -33,7 +32,7 @@ class GitHubTagsTest extends TestCase
         $handlerStack = HandlerStack::create($this->mockImagesResponseHandler(false));
         $client = new Client(['handler' => $handlerStack]);
 
-        /** @var DockerTags $dockerTags */
+        /** @var GitHubDockerTags $dockerTags */
         $dockerTags = M::mock(GitHubDockerTags::class, [$client, app(Buggregator::class)])->makePartial();
 
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
### Added

- Adds [Buggregator](https://buggregator.dev/) as a tool.

---

Hat tip to @gcavanunez for pointing me to Buggregator.

Usage:

```
takeout enable buggregator
```

After answering the prompted questions (about where the web UI, the VarDumper server, the Monolog server port, and network alias), the service should run at localhost:8000 (unless you change the default port).

### VarDumper Server

To start sending `dump()` calls to Buggregator, you may set the following configs on the Laravel app:

```env
VAR_DUMPER_FORMAT=server
VAR_DUMPER_SERVER=127.0.0.1:9912
# VAR_DUMPER_SERVER=buggregator:9912 # If you're on Sail
```

### Ray

First, on the Laravel app, require the Ray PHP client:

```bash
composer require spatie/laravel-ray --dev
```

Next, set the following configs:

```env
RAY_HOST=ray@127.0.0.1
# RAY_HOST=ray@buggregator # If you're on Sail
RAY_PORT=8000
```

### SMTP Server

To send emails, you may set the following configs on the Laravel app:

```env
MAIL_MAILER=smtp
MAIL_HOST=127.0.0.1
# MAIL_HOST=buggregator # If you're on Sail
MAIL_PORT=1025
```

### Profiler

Buggregator ships with an [XHProf](https://www.php.net/manual/en/book.xhprof.php) profiler. To use it, first install the `xhprof` extension via _pecl_:

```bash
pecl install xhprof
```

Then add the `extension=xhprof.so` to the `php.ini`. On Sail, you can do that with:

```bash
echo "extension=xhprof.so" >> /etc/php/8.3/cli/php.ini
```

Then, install the package:

```bash
composer require --dev maantje/xhprof-buggregator-laravel
```

Then, configure the profiler envs:

```env
PROFILER_ENDPOINT=http://profiler@127.0.0.1:8000
# PROFILER_ENDPOINT=http://profiler@buggregator:8000 # If you're on Sail
PROFILER_APP_NAME="${APP_NAME}"
XHPROF_ENABLED=true
```

### Sentry

First, install the package following sentry's [docs](https://docs.sentry.io/platforms/php/guides/laravel/#install).

Then, configure the Sentry DNS on the `.env` of your Laravel app:

```env
SENTRY_LARAVEL_DSN=http://sentry@127.0.0.1:8000/1
# SENTRY_LARAVEL_DSN=http://sentry@buggregator:8000/1 # If you're on sail
```

These should serve as examples. There's also a nice [monolog service](https://docs.buggregator.dev/config/monolog.html), an [inspector](https://docs.buggregator.dev/config/inspector.html), and an HTTP dump server.

### Notes on Sail

If you're using Takeout in combination with Sail, you can use the `network_alias` configured as the hostname (which defaults to `buggregator`) instead of `127.0.0.1`. The Laravel app container must be added to the Takeout network. For more info, check out [Matt's blog](https://mattstauffer.com/blog/how-to-use-takeout-to-add-new-services-to-laravel-sail-and-save-ram/).