### PR TITLE
Bump the guzzlehttp/ps7 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-json": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",
-        "guzzlehttp/psr7": "^1.7"
+        "guzzlehttp/psr7": "^2.6"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.4",


### PR DESCRIPTION
### Fixed

- Bumps the `guzzlehttp/ps7` dependency version to `^2.6`. I don't think there's a reason to stick to `^1.7`.

---

closes https://github.com/tighten/takeout/issues/279