### PR TITLE
MySQL Tweaks

### DIFF
--- a/app/Services/MySql.php
+++ b/app/Services/MySql.php
@@ -25,19 +25,10 @@ class MySql extends BaseService
 
     protected $dockerRunTemplate = '-p "${:port}":3306 \
         -e MYSQL_ROOT_PASSWORD="${:root_password}" \
-        -e MYSQL_ALLOW_EMPTY_PASSWORD="${:allow_empty_password}" \
+        -e MYSQL_ALLOW_EMPTY_PASSWORD="1" \
         -e MYSQL_ROOT_HOST="%" \
         -v "${:volume}":/var/lib/mysql \
-        "${:organization}"/"${:image_name}":"${:tag}" --default-authentication-plugin=mysql_native_password';
+        "${:organization}"/"${:image_name}":"${:tag}"';
 
     protected static $displayName = 'MySQL';
-
-    protected function buildParameters(): array
-    {
-        $parameters = parent::buildParameters();
-
-        $parameters['allow_empty_password'] = $parameters['root_password'] === '' ? '1' : '0';
-
-        return $parameters;
-    }
 }


### PR DESCRIPTION
### Changed

- In https://github.com/tighten/takeout/pull/330, we reverted back to the official MySQL image. After merging that PR, I noticed that it now complains about the `--default-authentication-plugin` flag that we are setting saying it doesn't exist (from https://github.com/tighten/takeout/pull/116). I don't see that same flag being set on [Laravel Sail](https://github.com/laravel/sail/blob/1.x/stubs/mysql.stub). After testing without it, I was able to connect from my host machine, then created a sample Laravel Sail project to use the Takeout MySQL container, and it works. So we're dropping it.
- The `MYSQL_ALLOW_EMPTY_PASSWORD` flag can always be set to `1` instead of making it dynamic based on the password used.