### PR TITLE
Feat: Null password support for Mariadb

### DIFF
--- a/app/Services/MariaDb.php
+++ b/app/Services/MariaDb.php
@@ -17,14 +17,24 @@ class MariaDb extends BaseService
         [
             'shortname' => 'root_password',
             'prompt' => 'What will the root password be?',
-            'default' => 'password',
+            'default' => '',
         ],
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":3306 \
         -e MYSQL_ROOT_PASSWORD="${:root_password}" \
+        -e MYSQL_ALLOW_EMPTY_PASSWORD="${:allow_empty_password}" \
         -v "${:volume}":/var/lib/mysql \
         "${:organization}"/"${:image_name}":"${:tag}"';
 
     protected static $displayName = 'MariaDB';
+
+    protected function buildParameters(): array
+    {
+        $parameters = parent::buildParameters();
+
+        $parameters["allow_empty_password"] = $parameters["root_password"] === "" ? "yes" : "no";
+
+        return $parameters;
+    }
 }


### PR DESCRIPTION
Heyo!

Took the logic from #115 and ported it for MariaDB. Spun up the container and I could connect with an empty password, so guessing that's all that needs to be done for testing.