### PR TITLE
Add a `takeout shell` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ takeout stop {container_id}
 takeout stop {container_id1} {container_id2}
 ```
 
+### Get a shell inside any Takeout container
+
+To get a shell inside any container that is started with Takeout, you may run:
+
+```bash
+takeout shell {service}
+```
+
+Here are some examples:
+
+```bash
+takeout shell mysql
+takeout shell neo4j
+takeotu shell pgvector
+```
+
+This will reuse the running container. Takeout will start either a `bash` or a `sh` process inside the container, depending on what the container supports (this is automatically handled by Takeout).
+
 ## Running multiple versions of a dependency
 
 Another of Takeout's benefits is that it allows you to have multiple versions of a dependency installed and running at the same time. That means, for example, that you can run both MySQL 5.7 and 8.0 at the same time, on different ports.

--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ Here are some examples:
 ```bash
 takeout shell mysql
 takeout shell neo4j
-takeotu shell pgvector
+takeout shell pgvector
 ```
 
-This will reuse the running container. Takeout will start either a `bash` or a `sh` process inside the container, depending on what the container supports (this is automatically handled by Takeout).
+This will open a shell inside the running container for the service you provide. Takeout will start either a `bash` or a `sh` process inside the container, depending on what the container supports.
 
 ## Running multiple versions of a dependency
 

--- a/app/Commands/ShellCommand.php
+++ b/app/Commands/ShellCommand.php
@@ -13,7 +13,6 @@ class ShellCommand extends Command
     const MENU_TITLE = 'Get a shell inside a running Takeout container.';
 
     protected $signature = 'shell {service}';
-
     protected $description = 'Get a shell inside a running Takeout container.';
 
     public function handle(Services $services): int

--- a/app/Commands/ShellCommand.php
+++ b/app/Commands/ShellCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Commands;
+
+use App\InitializesCommands;
+use App\Services;
+use Illuminate\Console\Command;
+
+class ShellCommand extends Command
+{
+    use InitializesCommands;
+
+    const MENU_TITLE = 'Get a shell inside a running Takeout container.';
+
+    protected $signature = 'shell {service}';
+
+    protected $description = 'Get a shell inside a running Takeout container.';
+
+    public function handle(Services $services): int
+    {
+        $this->initializecommand();
+
+        $service = $services->get($this->argument('service'));
+
+        resolve($service)->forwardShell();
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -103,7 +103,7 @@ abstract class BaseService
 
             $this->info("\nService enabled!");
         } catch (Throwable $e) {
-            $this->error("\n".$e->getMessage());
+            $this->error("\n" . $e->getMessage());
         }
     }
 
@@ -236,13 +236,13 @@ abstract class BaseService
         // Check if tag represents semantic version (v5.6.0, 5.7.4, or 8.0) and return major.minor
         // (eg mysql5.7) or return the actual tag prefixed by a dash (eg redis-buster)
         if (! preg_match('/v?(0|(?:[1-9]\d*))(?:\.(0|(?:[1-9]\d*))(?:\.(0|(?:[1-9]\d*)))?)/', $this->tag)) {
-            return $this->shortName()."-{$this->tag}";
+            return $this->shortName() . "-{$this->tag}";
         }
 
         $version = trim($this->tag, 'v');
         [$major, $minor] = explode('.', $version);
 
-        return $this->shortName()."{$major}.{$minor}";
+        return $this->shortName() . "{$major}.{$minor}";
     }
 
     protected function containerName(): string
@@ -254,7 +254,7 @@ abstract class BaseService
             }
         }
 
-        return 'TO--'.$this->shortName().'--'.$this->tag.$portTag;
+        return 'TO--' . $this->shortName() . '--' . $this->tag . $portTag;
     }
 
     public function sanitizeDockerRunTemplate($dockerRunTemplate): string

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -16,21 +16,13 @@ abstract class BaseService
     use WritesToConsole;
 
     protected static $category;
-
     protected static $displayName;
-
     protected $organization = 'library'; // Official repositories use `library` as the organization name.
-
     protected $imageName;
-
     protected $dockerTagsClass = DockerTags::class;
-
     protected $tag;
-
     protected $dockerRunTemplate;
-
     protected $defaultPort;
-
     protected $defaultPrompts = [
         [
             'shortname' => 'port',
@@ -43,17 +35,11 @@ abstract class BaseService
             'default' => 'latest',
         ],
     ];
-
     protected $prompts = [];
-
     protected $promptResponses = [];
-
     protected $shell;
-
     protected $environment;
-
     protected $docker;
-
     protected $useDefaults = false;
 
     public function __construct(Shell $shell, Environment $environment, Docker $docker)

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -17,6 +17,7 @@ abstract class BaseService
 
     protected static $category;
     protected static $displayName;
+
     protected $organization = 'library'; // Official repositories use `library` as the organization name.
     protected $imageName;
     protected $dockerTagsClass = DockerTags::class;
@@ -67,7 +68,7 @@ abstract class BaseService
         return static::$displayName ?? Str::afterLast(static::class, '\\');
     }
 
-    public function enable(bool $useDefaults = false, array $passthroughOptions = [], ?string $runOptions = null): void
+    public function enable(bool $useDefaults = false, array $passthroughOptions = [], string $runOptions = null): void
     {
         $this->useDefaults = $useDefaults;
 
@@ -79,7 +80,7 @@ abstract class BaseService
 
         try {
             $this->docker->bootContainer(
-                implode(' ', array_filter([
+                join(' ', array_filter([
                     $runOptions,
                     $this->sanitizeDockerRunTemplate($this->dockerRunTemplate),
                     $this->buildPassthroughOptionsString($passthroughOptions),
@@ -258,6 +259,6 @@ abstract class BaseService
             return '';
         }
 
-        return implode(' ', $passthroughOptions);
+        return join(' ', $passthroughOptions);
     }
 }

--- a/app/Services/Beanstalkd.php
+++ b/app/Services/Beanstalkd.php
@@ -5,13 +5,9 @@ namespace App\Services;
 class Beanstalkd extends BaseService
 {
     protected static $category = Category::CACHE;
-
     protected $organization = 'schickling';
-
     protected $imageName = 'beanstalkd';
-
     protected $defaultPort = 11300;
-
     protected $dockerRunTemplate = '-p "${:port}":11300 \
         "${:organization}"/"${:image_name}":"${:tag}"';
 

--- a/app/Services/Beanstalkd.php
+++ b/app/Services/Beanstalkd.php
@@ -7,9 +7,16 @@ class Beanstalkd extends BaseService
     protected static $category = Category::CACHE;
 
     protected $organization = 'schickling';
+
     protected $imageName = 'beanstalkd';
+
     protected $defaultPort = 11300;
 
     protected $dockerRunTemplate = '-p "${:port}":11300 \
         "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function shellCommand(): string
+    {
+        return 'sh';
+    }
 }

--- a/app/Services/Beanstalkd.php
+++ b/app/Services/Beanstalkd.php
@@ -5,9 +5,11 @@ namespace App\Services;
 class Beanstalkd extends BaseService
 {
     protected static $category = Category::CACHE;
+
     protected $organization = 'schickling';
     protected $imageName = 'beanstalkd';
     protected $defaultPort = 11300;
+
     protected $dockerRunTemplate = '-p "${:port}":11300 \
         "${:organization}"/"${:image_name}":"${:tag}"';
 

--- a/app/Services/Buggregator.php
+++ b/app/Services/Buggregator.php
@@ -7,6 +7,7 @@ use App\Shell\GitHubDockerTags;
 class Buggregator extends BaseService
 {
     protected static $category = Category::TOOLS;
+
     protected $dockerTagsClass = GitHubDockerTags::class;
     protected $organization = 'ghcr.io';
     protected $imageName = 'buggregator/server';
@@ -34,6 +35,7 @@ class Buggregator extends BaseService
             'default' => 'buggregator',
         ],
     ];
+
     protected $dockerRunTemplate = '-p "${:port}":8000 \
         -p "${:smtp_port}":1025 \
         -p "${:var_dumper_port}":9912 \

--- a/app/Services/Buggregator.php
+++ b/app/Services/Buggregator.php
@@ -7,17 +7,11 @@ use App\Shell\GitHubDockerTags;
 class Buggregator extends BaseService
 {
     protected static $category = Category::TOOLS;
-
     protected $dockerTagsClass = GitHubDockerTags::class;
-
     protected $organization = 'ghcr.io';
-
     protected $imageName = 'buggregator/server';
-
     protected $tag = 'latest';
-
     protected $defaultPort = 8000;
-
     protected $prompts = [
         [
             'shortname' => 'smtp_port',
@@ -40,7 +34,6 @@ class Buggregator extends BaseService
             'default' => 'buggregator',
         ],
     ];
-
     protected $dockerRunTemplate = '-p "${:port}":8000 \
         -p "${:smtp_port}":1025 \
         -p "${:var_dumper_port}":9912 \

--- a/app/Services/Buggregator.php
+++ b/app/Services/Buggregator.php
@@ -9,10 +9,15 @@ class Buggregator extends BaseService
     protected static $category = Category::TOOLS;
 
     protected $dockerTagsClass = GitHubDockerTags::class;
+
     protected $organization = 'ghcr.io';
+
     protected $imageName = 'buggregator/server';
+
     protected $tag = 'latest';
+
     protected $defaultPort = 8000;
+
     protected $prompts = [
         [
             'shortname' => 'smtp_port',
@@ -42,4 +47,9 @@ class Buggregator extends BaseService
         -p "${:monolog_port}":9913 \
         --network-alias "${:network_alias}" \
         "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function shellCommand(): string
+    {
+        return 'sh';
+    }
 }

--- a/app/Services/CouchDB.php
+++ b/app/Services/CouchDB.php
@@ -7,17 +7,31 @@ class CouchDB extends BaseService
     protected static $category = Category::DATABASE;
 
     protected $imageName = 'couchdb';
+
     protected $defaultPort = 5984;
+
     protected $prompts = [
         [
             'shortname' => 'volume',
             'prompt' => 'What is the Docker volume name?',
             'default' => 'couchdb_data',
         ],
+        [
+            'shortname' => 'user',
+            'prompt' => 'What is the CouchDB User?',
+            'default' => 'couchdb',
+        ],
+        [
+            'shortname' => 'password',
+            'prompt' => 'What is the CouchDB Password?',
+            'default' => 'password',
+        ],
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":5984 \
         -v "${:volume}":/opt/couchdb/data \
+        -e COUCHDB_USER="${:user}" \
+        -e COUCHDB_PASSWORD="${:password}" \
         "${:organization}"/"${:image_name}":"${:tag}"';
 
     protected static $displayName = 'CouchDB';

--- a/app/Services/CouchDB.php
+++ b/app/Services/CouchDB.php
@@ -5,6 +5,7 @@ namespace App\Services;
 class CouchDB extends BaseService
 {
     protected static $category = Category::DATABASE;
+
     protected $imageName = 'couchdb';
     protected $defaultPort = 5984;
     protected $prompts = [
@@ -24,10 +25,12 @@ class CouchDB extends BaseService
             'default' => 'password',
         ],
     ];
+
     protected $dockerRunTemplate = '-p "${:port}":5984 \
         -v "${:volume}":/opt/couchdb/data \
         -e COUCHDB_USER="${:user}" \
         -e COUCHDB_PASSWORD="${:password}" \
         "${:organization}"/"${:image_name}":"${:tag}"';
+
     protected static $displayName = 'CouchDB';
 }

--- a/app/Services/CouchDB.php
+++ b/app/Services/CouchDB.php
@@ -5,11 +5,8 @@ namespace App\Services;
 class CouchDB extends BaseService
 {
     protected static $category = Category::DATABASE;
-
     protected $imageName = 'couchdb';
-
     protected $defaultPort = 5984;
-
     protected $prompts = [
         [
             'shortname' => 'volume',
@@ -27,12 +24,10 @@ class CouchDB extends BaseService
             'default' => 'password',
         ],
     ];
-
     protected $dockerRunTemplate = '-p "${:port}":5984 \
         -v "${:volume}":/opt/couchdb/data \
         -e COUCHDB_USER="${:user}" \
         -e COUCHDB_PASSWORD="${:password}" \
         "${:organization}"/"${:image_name}":"${:tag}"';
-
     protected static $displayName = 'CouchDB';
 }

--- a/app/Services/EventStoreDB.php
+++ b/app/Services/EventStoreDB.php
@@ -5,13 +5,9 @@ namespace App\Services;
 class EventStoreDB extends BaseService
 {
     protected static $category = Category::DATABASE;
-
     protected $organization = 'eventstore';
-
     protected $imageName = 'eventstore';
-
     protected $defaultPort = 1113;
-
     protected $prompts = [
         [
             'shortname' => 'web_port',
@@ -24,7 +20,6 @@ class EventStoreDB extends BaseService
             'default' => 'eventstore_data',
         ],
     ];
-
     protected $dockerRunTemplate = '-p "${:port}":1113 \
         -p "${:web_port}":2113 \
         -v "${:volume}":/var/lib/eventstore \

--- a/app/Services/EventStoreDB.php
+++ b/app/Services/EventStoreDB.php
@@ -7,8 +7,11 @@ class EventStoreDB extends BaseService
     protected static $category = Category::DATABASE;
 
     protected $organization = 'eventstore';
+
     protected $imageName = 'eventstore';
+
     protected $defaultPort = 1113;
+
     protected $prompts = [
         [
             'shortname' => 'web_port',
@@ -25,7 +28,6 @@ class EventStoreDB extends BaseService
     protected $dockerRunTemplate = '-p "${:port}":1113 \
         -p "${:web_port}":2113 \
         -v "${:volume}":/var/lib/eventstore \
-        "${:organization}"/"${:image_name}":"${:tag}" \
-        --insecure --run-projections=All \
-        --enable-external-tcp --enable-atom-pub-over-http';
+        "${:organization}"/"${:image_name}":latest \
+        --insecure --run-projections=All';
 }

--- a/app/Services/EventStoreDB.php
+++ b/app/Services/EventStoreDB.php
@@ -5,6 +5,7 @@ namespace App\Services;
 class EventStoreDB extends BaseService
 {
     protected static $category = Category::DATABASE;
+
     protected $organization = 'eventstore';
     protected $imageName = 'eventstore';
     protected $defaultPort = 1113;
@@ -20,6 +21,7 @@ class EventStoreDB extends BaseService
             'default' => 'eventstore_data',
         ],
     ];
+
     protected $dockerRunTemplate = '-p "${:port}":1113 \
         -p "${:web_port}":2113 \
         -v "${:volume}":/var/lib/eventstore \

--- a/app/Services/MailDev.php
+++ b/app/Services/MailDev.php
@@ -7,8 +7,11 @@ class MailDev extends BaseService
     protected static $category = Category::MAIL;
 
     protected $organization = 'maildev';
+
     protected $imageName = 'maildev';
+
     protected $defaultPort = 1025;
+
     protected $prompts = [
         [
             'shortname' => 'web_port',
@@ -20,4 +23,9 @@ class MailDev extends BaseService
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":1080 \
         "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function shellCommand(): string
+    {
+        return 'sh';
+    }
 }

--- a/app/Services/MailDev.php
+++ b/app/Services/MailDev.php
@@ -5,6 +5,7 @@ namespace App\Services;
 class MailDev extends BaseService
 {
     protected static $category = Category::MAIL;
+
     protected $organization = 'maildev';
     protected $imageName = 'maildev';
     protected $defaultPort = 1025;
@@ -15,6 +16,7 @@ class MailDev extends BaseService
             'default' => '1080',
         ],
     ];
+
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":1080 \
         "${:organization}"/"${:image_name}":"${:tag}"';

--- a/app/Services/MailDev.php
+++ b/app/Services/MailDev.php
@@ -5,13 +5,9 @@ namespace App\Services;
 class MailDev extends BaseService
 {
     protected static $category = Category::MAIL;
-
     protected $organization = 'maildev';
-
     protected $imageName = 'maildev';
-
     protected $defaultPort = 1025;
-
     protected $prompts = [
         [
             'shortname' => 'web_port',
@@ -19,7 +15,6 @@ class MailDev extends BaseService
             'default' => '1080',
         ],
     ];
-
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":1080 \
         "${:organization}"/"${:image_name}":"${:tag}"';

--- a/app/Services/MailHog.php
+++ b/app/Services/MailHog.php
@@ -7,8 +7,11 @@ class MailHog extends BaseService
     protected static $category = Category::MAIL;
 
     protected $organization = 'mailhog';
+
     protected $imageName = 'mailhog';
+
     protected $defaultPort = 1025;
+
     protected $prompts = [
         [
             'shortname' => 'web_port',
@@ -20,4 +23,9 @@ class MailHog extends BaseService
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":8025 \
         "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function shellCommand(): string
+    {
+        return 'sh';
+    }
 }

--- a/app/Services/MailHog.php
+++ b/app/Services/MailHog.php
@@ -7,11 +7,8 @@ class MailHog extends BaseService
     protected static $category = Category::MAIL;
 
     protected $organization = 'mailhog';
-
     protected $imageName = 'mailhog';
-
     protected $defaultPort = 1025;
-
     protected $prompts = [
         [
             'shortname' => 'web_port',
@@ -19,7 +16,6 @@ class MailHog extends BaseService
             'default' => '8025',
         ],
     ];
-
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":8025 \
         "${:organization}"/"${:image_name}":"${:tag}"';

--- a/app/Services/MailHog.php
+++ b/app/Services/MailHog.php
@@ -16,6 +16,7 @@ class MailHog extends BaseService
             'default' => '8025',
         ],
     ];
+
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":8025 \
         "${:organization}"/"${:image_name}":"${:tag}"';

--- a/app/Services/Mailpit.php
+++ b/app/Services/Mailpit.php
@@ -7,8 +7,11 @@ class Mailpit extends BaseService
     protected static $category = Category::MAIL;
 
     protected $organization = 'axllent';
+
     protected $imageName = 'mailpit';
+
     protected $defaultPort = 1025;
+
     protected $prompts = [
         [
             'shortname' => 'web_port',
@@ -20,4 +23,9 @@ class Mailpit extends BaseService
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":8025 \
         "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function shellCommand(): string
+    {
+        return 'sh';
+    }
 }

--- a/app/Services/Mailpit.php
+++ b/app/Services/Mailpit.php
@@ -7,11 +7,8 @@ class Mailpit extends BaseService
     protected static $category = Category::MAIL;
 
     protected $organization = 'axllent';
-
     protected $imageName = 'mailpit';
-
     protected $defaultPort = 1025;
-
     protected $prompts = [
         [
             'shortname' => 'web_port',
@@ -19,7 +16,6 @@ class Mailpit extends BaseService
             'default' => '8025',
         ],
     ];
-
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":8025 \
         "${:organization}"/"${:image_name}":"${:tag}"';

--- a/app/Services/Mailpit.php
+++ b/app/Services/Mailpit.php
@@ -16,6 +16,7 @@ class Mailpit extends BaseService
             'default' => '8025',
         ],
     ];
+
     protected $dockerRunTemplate = '-p "${:port}":1025 \
         -p "${:web_port}":8025 \
         "${:organization}"/"${:image_name}":"${:tag}"';

--- a/app/Services/MeiliSearch.php
+++ b/app/Services/MeiliSearch.php
@@ -7,8 +7,11 @@ class MeiliSearch extends BaseService
     protected static $category = Category::SEARCH;
 
     protected $organization = 'getmeili';
+
     protected $imageName = 'meilisearch';
+
     protected $defaultPort = 7700;
+
     protected $prompts = [
         [
             'shortname' => 'volume',
@@ -20,4 +23,9 @@ class MeiliSearch extends BaseService
     protected $dockerRunTemplate = '-p "${:port}":7700 \
         -v "${:volume}":/data.ms \
         "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function shellCommand(): string
+    {
+        return 'sh';
+    }
 }

--- a/app/Services/MeiliSearch.php
+++ b/app/Services/MeiliSearch.php
@@ -7,11 +7,8 @@ class MeiliSearch extends BaseService
     protected static $category = Category::SEARCH;
 
     protected $organization = 'getmeili';
-
     protected $imageName = 'meilisearch';
-
     protected $defaultPort = 7700;
-
     protected $prompts = [
         [
             'shortname' => 'volume',

--- a/app/Services/OpenSearch.php
+++ b/app/Services/OpenSearch.php
@@ -7,8 +7,11 @@ class OpenSearch extends BaseService
     protected static $category = Category::SEARCH;
 
     protected $organization = 'opensearchproject';
+
     protected $imageName = 'opensearch';
+
     protected $defaultPort = 9200;
+
     protected $prompts = [
         [
             'shortname' => 'volume',
@@ -23,7 +26,7 @@ class OpenSearch extends BaseService
         [
             'shortname' => 'disable_security',
             'prompt' => 'Disable security plugin (true or false)?',
-            'default' => 'false',
+            'default' => 'true',
         ],
     ];
 

--- a/app/Services/OpenSearch.php
+++ b/app/Services/OpenSearch.php
@@ -7,11 +7,8 @@ class OpenSearch extends BaseService
     protected static $category = Category::SEARCH;
 
     protected $organization = 'opensearchproject';
-
     protected $imageName = 'opensearch';
-
     protected $defaultPort = 9200;
-
     protected $prompts = [
         [
             'shortname' => 'volume',

--- a/app/Services/Soketi.php
+++ b/app/Services/Soketi.php
@@ -12,15 +12,10 @@ class Soketi extends BaseService
     protected static $category = Category::SOCKET;
 
     protected $dockerTagsClass = QuayDockerTags::class;
-
     protected $organization = 'quay.io';
-
     protected $imageName = 'soketi/soketi';
-
     protected $tag = 'latest-16-alpine';
-
     protected $defaultPort = 6001;
-
     protected $prompts = [
         [
             'shortname' => 'metrics_port',

--- a/app/Services/Soketi.php
+++ b/app/Services/Soketi.php
@@ -12,10 +12,15 @@ class Soketi extends BaseService
     protected static $category = Category::SOCKET;
 
     protected $dockerTagsClass = QuayDockerTags::class;
+
     protected $organization = 'quay.io';
+
     protected $imageName = 'soketi/soketi';
+
     protected $tag = 'latest-16-alpine';
+
     protected $defaultPort = 6001;
+
     protected $prompts = [
         [
             'shortname' => 'metrics_port',
@@ -40,5 +45,10 @@ class Soketi extends BaseService
 
             return $prompt;
         }, $this->defaultPrompts);
+    }
+
+    protected function shellCommand(): string
+    {
+        return 'sh';
     }
 }

--- a/app/Services/Traefik.php
+++ b/app/Services/Traefik.php
@@ -12,11 +12,8 @@ class Traefik extends BaseService
     protected static $category = Category::TOOLS;
 
     protected $imageName = 'traefik';
-
     protected $defaultTag = 'v2.10';
-
     protected $defaultPort = 8080;
-
     protected $prompts = [
         [
             'shortname' => 'config_dir',

--- a/app/Services/Traefik.php
+++ b/app/Services/Traefik.php
@@ -64,6 +64,11 @@ class Traefik extends BaseService
         }, $this->prompts);
     }
 
+    protected function shellCommand(): string
+    {
+        return 'sh';
+    }
+
     protected function prompts(): void
     {
         parent::prompts();

--- a/app/Shell/Docker.php
+++ b/app/Shell/Docker.php
@@ -37,10 +37,10 @@ class Docker
             $this->stopContainer($containerId);
         }
 
-        $process = $this->shell->exec('docker rm '.$containerId);
+        $process = $this->shell->exec('docker rm ' . $containerId);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed removing container '.$containerId);
+            throw new Exception('Failed removing container ' . $containerId);
         }
     }
 
@@ -52,10 +52,10 @@ class Docker
             throw new DockerContainerMissingException($containerId);
         }
 
-        $process = $this->shell->exec('docker stop '.$containerId);
+        $process = $this->shell->exec('docker stop ' . $containerId);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed stopping container '.$containerId);
+            throw new Exception('Failed stopping container ' . $containerId);
         }
     }
 
@@ -67,10 +67,10 @@ class Docker
             throw new DockerContainerMissingException($containerId);
         }
 
-        $process = $this->shell->exec('docker logs -f '.$containerId);
+        $process = $this->shell->exec('docker logs -f ' . $containerId);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed to log container '.$containerId);
+            throw new Exception('Failed to log container ' . $containerId);
         }
     }
 
@@ -82,10 +82,10 @@ class Docker
             throw new DockerContainerMissingException($containerId);
         }
 
-        $process = $this->shell->exec('docker start '.$containerId);
+        $process = $this->shell->exec('docker start ' . $containerId);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed starting container '.$containerId);
+            throw new Exception('Failed starting container ' . $containerId);
         }
     }
 
@@ -171,7 +171,7 @@ class Docker
         $process = $this->shell->exec($command, $parameters);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed installing '.$parameters['image_name']);
+            throw new Exception('Failed installing ' . $parameters['image_name']);
         }
     }
 
@@ -198,7 +198,7 @@ class Docker
             $this->shell->execQuietly('systemctl stop docker');
         } else {
             // BSD, Solaris, Unknown
-            throw new Exception('Cannot stop Docker in PHP_OS_FAMILY '.PHP_OS_FAMILY);
+            throw new Exception('Cannot stop Docker in PHP_OS_FAMILY ' . PHP_OS_FAMILY);
         }
     }
 
@@ -206,7 +206,8 @@ class Docker
     {
         $command = $this->shell->buildProcess(sprintf(
             'docker exec -it "%s" %s',
-            $containerId, $shellCommand,
+            $containerId,
+            $shellCommand,
         ));
 
         $command->setTty(true);

--- a/app/Shell/Docker.php
+++ b/app/Shell/Docker.php
@@ -3,7 +3,6 @@
 namespace App\Shell;
 
 use App\Exceptions\DockerContainerMissingException;
-use App\Shell\Environment;
 use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -11,8 +10,11 @@ use Illuminate\Support\Str;
 class Docker
 {
     protected $shell;
+
     protected $formatter;
+
     protected $networking;
+
     protected $environment;
 
     public function __construct(
@@ -35,10 +37,10 @@ class Docker
             $this->stopContainer($containerId);
         }
 
-        $process = $this->shell->exec('docker rm ' . $containerId);
+        $process = $this->shell->exec('docker rm '.$containerId);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed removing container ' . $containerId);
+            throw new Exception('Failed removing container '.$containerId);
         }
     }
 
@@ -50,10 +52,10 @@ class Docker
             throw new DockerContainerMissingException($containerId);
         }
 
-        $process = $this->shell->exec('docker stop ' . $containerId);
+        $process = $this->shell->exec('docker stop '.$containerId);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed stopping container ' . $containerId);
+            throw new Exception('Failed stopping container '.$containerId);
         }
     }
 
@@ -65,10 +67,10 @@ class Docker
             throw new DockerContainerMissingException($containerId);
         }
 
-        $process = $this->shell->exec('docker logs -f ' . $containerId);
+        $process = $this->shell->exec('docker logs -f '.$containerId);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed to log container ' . $containerId);
+            throw new Exception('Failed to log container '.$containerId);
         }
     }
 
@@ -80,10 +82,10 @@ class Docker
             throw new DockerContainerMissingException($containerId);
         }
 
-        $process = $this->shell->exec('docker start ' . $containerId);
+        $process = $this->shell->exec('docker start '.$containerId);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed starting container ' . $containerId);
+            throw new Exception('Failed starting container '.$containerId);
         }
     }
 
@@ -169,7 +171,7 @@ class Docker
         $process = $this->shell->exec($command, $parameters);
 
         if (! $process->isSuccessful()) {
-            throw new Exception('Failed installing ' . $parameters['image_name']);
+            throw new Exception('Failed installing '.$parameters['image_name']);
         }
     }
 
@@ -196,8 +198,20 @@ class Docker
             $this->shell->execQuietly('systemctl stop docker');
         } else {
             // BSD, Solaris, Unknown
-            throw new Exception('Cannot stop Docker in PHP_OS_FAMILY ' . PHP_OS_FAMILY);
+            throw new Exception('Cannot stop Docker in PHP_OS_FAMILY '.PHP_OS_FAMILY);
         }
+    }
+
+    public function forwardShell(string $containerId, string $shellCommand): void
+    {
+        $command = $this->shell->buildProcess(sprintf(
+            'docker exec -it "%s" %s',
+            $containerId, $shellCommand,
+        ));
+
+        $command->setTty(true);
+        $command->setTimeout(null);
+        $command->run();
     }
 
     protected function runAndParseTable(string $command): Collection

--- a/app/Shell/Docker.php
+++ b/app/Shell/Docker.php
@@ -10,11 +10,8 @@ use Illuminate\Support\Str;
 class Docker
 {
     protected $shell;
-
     protected $formatter;
-
     protected $networking;
-
     protected $environment;
 
     public function __construct(

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -42,7 +42,7 @@ class DockerTagsTest extends TestCase
         $tags = collect($dockerTags->getTags());
 
         $this->assertEquals('latest', $tags->shift());
-        $this->assertEquals('16.3', $tags->shift());
+        $this->assertEquals('16.4', $tags->shift());
     }
 
     /** @test */

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -42,7 +42,7 @@ class DockerTagsTest extends TestCase
         $tags = collect($dockerTags->getTags());
 
         $this->assertEquals('latest', $tags->shift());
-        $this->assertEquals('16.4', $tags->shift());
+        $this->assertEquals('17.0', $tags->shift());
     }
 
     /** @test */


### PR DESCRIPTION
### Added

- Adds a `takeout shell {service}` command to get a shell inside any container started with Takeout
- Fixes the CouchDB not starting. Looks like we now need to pass a user and password config
- Fixes the EventStoreDB. The flags that were passed no longer work
- Fixes OpenSearch not starting, the security plugin should be disabled by default

---

closes #348 