### PR TITLE
Adds Ollama and OpenWebUI services as tools

### DIFF
--- a/app/Services/Ollama.php
+++ b/app/Services/Ollama.php
@@ -36,7 +36,7 @@ class Ollama extends BaseService
         parent::prompts();
 
         if (! in_array(strtolower(trim($this->promptResponses['use_gpu'])), ['no', 'n', '0', 'false', ''])) {
-            $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
+            $this->dockerRunTemplate = '--gpus=all ' . $this->dockerRunTemplate;
         }
     }
 }

--- a/app/Services/Ollama.php
+++ b/app/Services/Ollama.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services;
+
+class Ollama extends BaseService
+{
+    protected static $category = Category::TOOLS;
+
+    protected $organization = 'ollama';
+
+    protected $imageName = 'ollama';
+
+    protected $defaultPort = 11434;
+
+    protected $prompts = [
+        [
+            'shortname' => 'volume',
+            'prompt' => 'Volume name (Ollama will store the models locally)',
+            'default' => 'ollama_data',
+        ],
+        [
+            'shortname' => 'cpuOnly',
+            'prompt' => 'CPU only? Leave blank for yes. (Docker does not support GPUs on Mac)',
+            'default' => '',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-d --add-host=host.docker.internal:host-gateway --network-alias "takeout-ollama"  -v "${:volume}":/root/.ollama -p "${:port}":11434 "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function prompts(): void
+    {
+        parent::prompts();
+
+        if (trim($this->promptResponses['cpuOnly']) !== '') {
+            $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
+        }
+    }
+}

--- a/app/Services/Ollama.php
+++ b/app/Services/Ollama.php
@@ -20,7 +20,7 @@ class Ollama extends BaseService
         ],
         [
             'shortname' => 'use_gpu',
-            'prompt' => 'Do want to GPUs? Docker on Mac doesn\'t support GPUs. Default is "no", meaning CPU-only. To use GPUs, answer "yes".',
+            'prompt' => 'Do want to use your GPUs? Docker on Mac doesn\'t support GPUs. Default is "no", meaning CPU-only. To use GPUs, answer "yes".',
             'default' => 'no',
         ],
     ];
@@ -36,7 +36,7 @@ class Ollama extends BaseService
         parent::prompts();
 
         if (! in_array(strtolower(trim($this->promptResponses['use_gpu'])), ['no', 'n', '0', 'false', ''])) {
-            $this->dockerRunTemplate = '--gpus=all ' . $this->dockerRunTemplate;
+            $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
         }
     }
 }

--- a/app/Services/Ollama.php
+++ b/app/Services/Ollama.php
@@ -15,23 +15,27 @@ class Ollama extends BaseService
     protected $prompts = [
         [
             'shortname' => 'volume',
-            'prompt' => 'Volume name (Ollama will store the models locally)',
+            'prompt' => 'Volume Name (Ollama will store the models locally)',
             'default' => 'ollama_data',
         ],
         [
-            'shortname' => 'cpuOnly',
-            'prompt' => 'CPU only? Leave blank for yes. (Docker does not support GPUs on Mac)',
-            'default' => '',
+            'shortname' => 'use_gpu',
+            'prompt' => 'Do want to GPUs? Docker on Mac doesn\'t support GPUs. Default is "no", meaning CPU-only. To use GPUs, answer "yes".',
+            'default' => 'no',
         ],
     ];
 
-    protected $dockerRunTemplate = '-d --add-host=host.docker.internal:host-gateway --network-alias "takeout-ollama"  -v "${:volume}":/root/.ollama -p "${:port}":11434 "${:organization}"/"${:image_name}":"${:tag}"';
+    protected $dockerRunTemplate = '-d --add-host=host.docker.internal:host-gateway \
+        --network-alias "takeout-ollama" \
+        -v "${:volume}":/root/.ollama \
+        -p "${:port}":11434 \
+        "${:organization}"/"${:image_name}":"${:tag}"';
 
     protected function prompts(): void
     {
         parent::prompts();
 
-        if (trim($this->promptResponses['cpuOnly']) !== '') {
+        if (! in_array(strtolower(trim($this->promptResponses['use_gpu'])), ['no', 'n', '0', 'false', ''])) {
             $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
         }
     }

--- a/app/Services/OpenWebui.php
+++ b/app/Services/OpenWebui.php
@@ -48,7 +48,7 @@ class OpenWebui extends BaseService
         parent::prompts();
 
         if (! in_array(strtolower(trim($this->promptResponses['use_gpu'])), ['no', 'n', '0', 'false', ''])) {
-            $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
+            $this->dockerRunTemplate = '--gpus=all ' . $this->dockerRunTemplate;
         }
     }
 }

--- a/app/Services/OpenWebui.php
+++ b/app/Services/OpenWebui.php
@@ -25,9 +25,9 @@ class OpenWebui extends BaseService
             'default' => 'webui_data',
         ],
         [
-            'shortname' => 'cpu_only',
-            'prompt' => 'CPU only? Leave blank for yes. (Docker does not support GPUs on Mac)',
-            'default' => '',
+            'shortname' => 'use_gpu',
+            'prompt' => 'Do want to GPUs? Docker on Mac doesn\'t support GPUs. Default is "no", meaning CPU-only. To use GPUs, answer "yes".',
+            'default' => 'no',
         ],
         [
             'shortname' => 'ollama_server',
@@ -36,13 +36,18 @@ class OpenWebui extends BaseService
         ],
     ];
 
-    protected $dockerRunTemplate = '-d --add-host=host.docker.internal:host-gateway -e OLLAMA_BASE_URL="${:ollama_server}" -e WEBUI_AUTH=False -v "${:volume}":/app/backend/data -p "${:port}":8080 "${:organization}"/"${:image_name}":"${:tag}"';
+    protected $dockerRunTemplate = '-d --add-host=host.docker.internal:host-gateway \
+        -e OLLAMA_BASE_URL="${:ollama_server}" \
+        -e WEBUI_AUTH=False \
+        -v "${:volume}":/app/backend/data \
+        -p "${:port}":8080 \
+        "${:organization}"/"${:image_name}":"${:tag}"';
 
     protected function prompts(): void
     {
         parent::prompts();
 
-        if (trim($this->promptResponses['cpu_only']) !== '') {
+        if (! in_array(strtolower(trim($this->promptResponses['use_gpu'])), ['no', 'n', '0', 'false', ''])) {
             $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
         }
     }

--- a/app/Services/OpenWebui.php
+++ b/app/Services/OpenWebui.php
@@ -26,7 +26,7 @@ class OpenWebui extends BaseService
         ],
         [
             'shortname' => 'use_gpu',
-            'prompt' => 'Do want to GPUs? Docker on Mac doesn\'t support GPUs. Default is "no", meaning CPU-only. To use GPUs, answer "yes".',
+            'prompt' => 'Do want to use your GPUs? Docker on Mac doesn\'t support GPUs. Default is "no", meaning CPU-only. To use GPUs, answer "yes".',
             'default' => 'no',
         ],
         [
@@ -48,7 +48,7 @@ class OpenWebui extends BaseService
         parent::prompts();
 
         if (! in_array(strtolower(trim($this->promptResponses['use_gpu'])), ['no', 'n', '0', 'false', ''])) {
-            $this->dockerRunTemplate = '--gpus=all ' . $this->dockerRunTemplate;
+            $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
         }
     }
 }

--- a/app/Services/OpenWebui.php
+++ b/app/Services/OpenWebui.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services;
+
+use App\Shell\GitHubDockerTags;
+
+class OpenWebui extends BaseService
+{
+    protected static $category = Category::TOOLS;
+
+    protected $dockerTagsClass = GitHubDockerTags::class;
+
+    protected $organization = 'ghcr.io';
+
+    protected $imageName = 'open-webui/open-webui';
+
+    protected $tag = 'main';
+
+    protected $defaultPort = 3000;
+
+    protected $prompts = [
+        [
+            'shortname' => 'volume',
+            'prompt' => 'Volume Name (to store your app data, like chats, customizations, etc.)',
+            'default' => 'webui_data',
+        ],
+        [
+            'shortname' => 'cpu_only',
+            'prompt' => 'CPU only? Leave blank for yes. (Docker does not support GPUs on Mac)',
+            'default' => '',
+        ],
+        [
+            'shortname' => 'ollama_server',
+            'prompt' => 'Where is the Ollama server running?',
+            'default' => 'http://takeout-ollama:11434',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-d --add-host=host.docker.internal:host-gateway -e OLLAMA_BASE_URL="${:ollama_server}" -e WEBUI_AUTH=False -v "${:volume}":/app/backend/data -p "${:port}":8080 "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function prompts(): void
+    {
+        parent::prompts();
+
+        if (trim($this->promptResponses['cpu_only']) !== '') {
+            $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
+        }
+    }
+}

--- a/app/Services/OpenWebui.php
+++ b/app/Services/OpenWebui.php
@@ -22,7 +22,7 @@ class OpenWebui extends BaseService
         [
             'shortname' => 'volume',
             'prompt' => 'Volume Name (to store your app data, like chats, customizations, etc.)',
-            'default' => 'webui_data',
+            'default' => 'openwebui_data',
         ],
         [
             'shortname' => 'use_gpu',
@@ -48,7 +48,7 @@ class OpenWebui extends BaseService
         parent::prompts();
 
         if (! in_array(strtolower(trim($this->promptResponses['use_gpu'])), ['no', 'n', '0', 'false', ''])) {
-            $this->dockerRunTemplate = '--gpus=all '.$this->dockerRunTemplate;
+            $this->dockerRunTemplate = '--gpus=all ' . $this->dockerRunTemplate;
         }
     }
 }

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -42,7 +42,7 @@ class DockerTagsTest extends TestCase
         $tags = collect($dockerTags->getTags());
 
         $this->assertEquals('latest', $tags->shift());
-        $this->assertEquals('16.3', $tags->shift());
+        $this->assertEquals('17.1', $tags->shift());
     }
 
     /** @test */


### PR DESCRIPTION
### Changelog

- Adds Ollama as a tool
- Adds OpenWebUI as a tool

---

These both tools should work together. But we can use Ollama without the OpenWebUI tool (in case we're using Ollama in an application).

To run the Ollama tool (use defaults):

```bash
php ./takeout enable ollama
```

To run the OpenWebUI (use defaults):

```bash
php ./takeout enable openwebui
```

This should start Ollama at port `11434` and OpenWebUI at port `3000`. 

Open [http://localhost:3000](http://localhost:3000) (it takes a while for OpenWebUI to load), navigate to the top-right corner Admin Panel menu:

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/9b410319-7c26-4912-a51b-22f0b0a77565)

</details>

Then, to the Settings -> Models section, choose a model (like `llama3`), then hit the download button... this will take a while...

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/112d4076-fe08-49f9-9cd5-bc48990006bd)

</details>

Once it's done downloading, you can hit "New Chat" at the top-left corner, then choose the downloaded model in the model dropdown, then use it

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/55b28b0a-e3e1-4333-84bf-3cef8c54aa73)

</details>

