### PR TITLE
Adds a Reverb Service

### DIFF
--- a/app/Services/Reverb.php
+++ b/app/Services/Reverb.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+class Reverb extends BaseService
+{
+    protected static $category = Category::SOCKET;
+
+    protected $organization = 'tighten';
+    protected $imageName = 'takeout-reverb-server';
+    protected $tag = 'latest';
+    protected $defaultPort = 6001;
+    protected $prompts = [
+        [
+            'shortname' => 'dashboard_port',
+            'prompt' => 'Pulse Dashboard Port',
+            'default' => '9601',
+        ],
+        [
+            'shortname' => 'app_id',
+            'prompt' => 'Reverb App ID',
+            'default' => 'app-id',
+        ],
+        [
+            'shortname' => 'app_key',
+            'prompt' => 'Reverb App Key',
+            'default' => 'app-key',
+        ],
+        [
+            'shortname' => 'app_secret',
+            'prompt' => 'Reverb App Secret',
+            'default' => 'app-secret',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "${:port}":6001 \
+        -p "${:dashboard_port}":9601 \
+        -e REVERB_APP_KEY="${:app_key}" \
+        -e REVERB_APP_SECRET="${:app_secret}" \
+        -e REVERB_APP_ID="${:app_id}" \
+        "${:organization}"/"${:image_name}":"${:tag}"';
+
+    protected function shellCommand(): string
+    {
+        return 'sh';
+    }
+}

--- a/app/Services/Reverb.php
+++ b/app/Services/Reverb.php
@@ -38,6 +38,8 @@ class Reverb extends BaseService
         -e REVERB_APP_KEY="${:app_key}" \
         -e REVERB_APP_SECRET="${:app_secret}" \
         -e REVERB_APP_ID="${:app_id}" \
+        -e REVERB_SERVER_HOST="0.0.0.0" \
+        -e REVERB_SERVER_PORT="${:port}" \
         "${:organization}"/"${:image_name}":"${:tag}"';
 
     protected function shellCommand(): string

--- a/app/Services/Reverb.php
+++ b/app/Services/Reverb.php
@@ -40,6 +40,9 @@ class Reverb extends BaseService
         -e REVERB_APP_ID="${:app_id}" \
         -e REVERB_SERVER_HOST="0.0.0.0" \
         -e REVERB_SERVER_PORT="${:port}" \
+        -e REVERB_HOST="0.0.0.0" \
+        -e REVERB_PORT="${:port}" \
+        -e REVERB_SCHEME="http" \
         "${:organization}"/"${:image_name}":"${:tag}"';
 
     protected function shellCommand(): string


### PR DESCRIPTION
### Changes

- Adds a Laravel Reverb service, similar to our [Soketi](https://github.com/tighten/takeout/blob/main/app/Services/Soketi.php) offer. By default, we're using the same ports and configs as the current Soketi option, so Reverb should be a drop-in replacement for that.

---

It starts the WebSockets server on port 6001. The Pulse dashboard starts on port 9601 (same as the metrics dashboard on Soketi).

The Reverb service uses our own custom [Takeout Reverb Server](https://github.com/tighten/takeout-reverb-docker-image) Docker image, since Reverb doesn't have an official image. That image is not suited for production, but works fine for our use case here.

closes #345 