### PR TITLE
Add initial admin password prompt to OpenSearch service

### DIFF
--- a/app/Services/OpenSearch.php
+++ b/app/Services/OpenSearch.php
@@ -25,11 +25,17 @@ class OpenSearch extends BaseService
             'prompt' => 'Disable security plugin (true or false)?',
             'default' => 'true',
         ],
+        [
+            'shortname' => 'password',
+            'prompt' => 'What is the initial admin password?',
+            'default' => 'admin',
+        ],
     ];
 
     protected $dockerRunTemplate = '-p "${:port}":9200 \
         -p "${:analyzer_port}":9600 \
         -e DISABLE_SECURITY_PLUGIN="${:disable_security}"  \
+        -e OPENSEARCH_INITIAL_ADMIN_PASSWORD="${:password}" \
         -e "discovery.type=single-node"  \
         -v "${:volume}":/usr/share/opensearch/data \
         "${:organization}"/"${:image_name}":"${:tag}"';

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -49,7 +49,7 @@ class DockerTagsTest extends TestCase
         $tags = collect($dockerTags->getTags());
 
         $this->assertEquals('latest', $tags->shift());
-        $this->assertEquals('17.2', $tags->shift());
+        $this->assertEquals('17.4', $tags->shift());
     }
 
     /**


### PR DESCRIPTION
Spinning up OpenSearch running `takeout enable opensearch` using all the default prompts results in the following crash from docker:
> snapshot of logs:
```txt
Enabling OpenSearch Security Plugin
Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin 
OpenSearch 2.12.0 onwards, the OpenSearch Security Plugin a change that requires an initial password for 'admin' user. 
Please define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string. 
If a password is not provided, the setup will quit. 
 For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/
### OpenSearch Security Demo Installer
### ** Warning: Do not use on production or public reachable systems **
OpenSearch install type: rpm/deb on Linux 6.12.10-orbstack-00297-gf8f6e015b993 aarch64
OpenSearch config dir: /usr/share/opensearch/config/
OpenSearch config file: /usr/share/opensearch/config/opensearch.yml
OpenSearch bin dir: /usr/share/opensearch/bin/
OpenSearch plugins dir: /usr/share/opensearch/plugins/
OpenSearch lib dir: /usr/share/opensearch/lib/
Detected OpenSearch Version: 3.0.0-alpha1
Detected OpenSearch Security Version: 3.0.0.0-alpha1
No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD.
```

According to their [docs](https://opensearch.org/downloads.html)


> Note for OpenSearch 2.12 or later: Fresh installs of 2.12 or later require that you define an admin password — using the OPENSEARCH_INITIAL_ADMIN_PASSWORD environment variable — when configuring the security demo. For more information, see Setting up a demo configuration.


This PR just introduces another additional prompt to set that environment variable on the docker compose setup script.

Running `takeout enable opensearch` post update allows opensearch to properly run: `http://localhost:9200/`
![image](https://github.com/user-attachments/assets/a68be260-3ce5-4017-beda-cd3ada3f8b39)

