### PR TITLE
Added Valkey

### DIFF
--- a/app/Services/Valkey.php
+++ b/app/Services/Valkey.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services;
+
+class Valkey extends BaseService
+{
+    protected static $category = Category::CACHE;
+
+    protected $organization = 'valkey';
+    protected $imageName = 'valkey';
+    protected $defaultPort = 6379;
+    protected $prompts = [
+        [
+            'shortname' => 'volume',
+            'prompt' => 'What is the Docker volume name?',
+            'default' => 'valkey_data',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "${:port}":6379 \
+        -v "${:volume}":/data \
+        "${:organization}"/"${:image_name}":"${:tag}"';
+}

--- a/tests/Feature/DockerTagsTest.php
+++ b/tests/Feature/DockerTagsTest.php
@@ -49,7 +49,7 @@ class DockerTagsTest extends TestCase
         $tags = collect($dockerTags->getTags());
 
         $this->assertEquals('latest', $tags->shift());
-        $this->assertEquals('17.4', $tags->shift());
+        $this->assertEquals('17.5', $tags->shift());
     }
 
     /**


### PR DESCRIPTION
Some folks are using Valkey in production and it would be nice to be able to use it for development as well.  As of right now it works with the php redis libraries as a drop-in replacement for Redis.

Fixes #379 