### PR TITLE
Swaps the edge image for the MSSQL Server Express edition

### DIFF
--- a/app/Services/MsSql.php
+++ b/app/Services/MsSql.php
@@ -8,8 +8,10 @@ class MsSql extends BaseService
 {
     protected static $category = Category::DATABASE;
 
+    protected static $displayName = 'MS SQL Server';
+
     protected $organization = 'mcr.microsoft.com';
-    protected $imageName = 'azure-sql-edge';
+    protected $imageName = 'mssql/server';
     protected $dockerTagsClass = MicrosoftDockerTags::class;
     protected $defaultPort = 1433;
     protected $prompts = [
@@ -27,9 +29,8 @@ class MsSql extends BaseService
 
     protected $dockerRunTemplate = '-p "${:port}":1433 \
         -e ACCEPT_EULA=Y \
+        -e MSSQL_PID=Express \
         -e SA_PASSWORD="${:sa_password}" \
         -v "${:volume}":/var/opt/mssql \
         "${:organization}"/"${:image_name}":"${:tag}"';
-
-    protected static $displayName = 'MS SQL Server';
 }


### PR DESCRIPTION
### Changed

- The azure-edge is gonna get retired soon, and [they recommend](https://azure.microsoft.com/en-us/updates?id=azure-sql-edge-retirement ) going with the Express for use cases like ours.

---

closes #380